### PR TITLE
SteamLibrary: Fix error when trying to add VR features. Fixes #43

### DIFF
--- a/source/Libraries/SteamLibrary/SteamShared/MetadataProvider.cs
+++ b/source/Libraries/SteamLibrary/SteamShared/MetadataProvider.cs
@@ -329,9 +329,9 @@ namespace Steam
                     gameInfo.Developers = new List<string>(downloadedMetadata.StoreDetails.developers);
                 }
 
+                gameInfo.Features = new List<string>(); 
                 if (downloadedMetadata.StoreDetails.categories.HasItems())
                 {
-                    gameInfo.Features = new List<string>();
                     foreach (var category in downloadedMetadata.StoreDetails.categories)
                     {
                         // Ignore VR category, will be set from appinfo


### PR DESCRIPTION
Fix error when trying to add VR features when the list has not been initialized. Fixes #43

Built and tested in Playnite 9.