### PR TITLE
SteamLibrary: Fix certain games not downloading metadata due to required_age property in response. Fixes #45

### DIFF
--- a/source/Libraries/SteamLibrary/SteamShared/StoreAppDetailsResult.cs
+++ b/source/Libraries/SteamLibrary/SteamShared/StoreAppDetailsResult.cs
@@ -94,7 +94,7 @@ namespace Steam.Models
             public string type;
             public string name;
             public int steam_appid;
-            public int required_age;
+            public string required_age;
             public bool is_free;
             public List<int> dlc;
             public string header_image;


### PR DESCRIPTION
Fix certain games not downloading metadata due to required_age property in response. Fixes #45

Built and tested in Playnite 9.