### PR TITLE
Steam: Add setting to configure fallback from vertical cover to banner cover

### DIFF
--- a/source/Libraries/SteamLibrary/SteamLibrarySettingsView.xaml
+++ b/source/Libraries/SteamLibrary/SteamLibrarySettingsView.xaml
@@ -122,10 +122,13 @@
         <CheckBox Content="{DynamicResource LOCSteamShowFriendsButton}"
                   IsChecked="{Binding Settings.ShowFriendsButton}" Margin="0,20,0,10" />
 
-        <CheckBox Content="{DynamicResource LOCSteamUseVerticalCovers}"
+        <CheckBox Name="CheckUseVerticalCovers" Content="{DynamicResource LOCSteamUseVerticalCovers}"
                   Visibility="{Binding IsFirstRunUse, Converter={pcon:InvertedBooleanToVisibilityConverter}}"
-                  IsChecked="{Binding Settings.DownloadVerticalCovers}" Margin="0,0,0,5" />
-
+                  IsChecked="{Binding Settings.DownloadVerticalCovers}" Margin="0,0,0,10" />
+        <CheckBox Content="{DynamicResource LOCSteamDownloadFallbackBannerCovers}" IsEnabled="{Binding IsChecked, ElementName=CheckUseVerticalCovers}"
+                  Visibility="{Binding IsFirstRunUse, Converter={pcon:InvertedBooleanToVisibilityConverter}}"
+                  IsChecked="{Binding Settings.DownloadFallbackBannerCovers}" Margin="40,0,0,5" />
+        
         <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="0,5,0,5" HorizontalAlignment="Left"
                     ToolTip="{DynamicResource LOCBackgroundImageScreenOptionTooltip}"
                     ToolTipService.InitialShowDelay="0"

--- a/source/Libraries/SteamLibrary/SteamLibrarySettingsViewModel.cs
+++ b/source/Libraries/SteamLibrary/SteamLibrarySettingsViewModel.cs
@@ -28,6 +28,7 @@ namespace SteamLibrary
     {
         public int Version { get; set; }
         public bool DownloadVerticalCovers { get; set; } = true;
+        public bool DownloadFallbackBannerCovers { get; set; } = false;
         public bool ImportInstalledGames { get; set; } = true;
         public bool ConnectAccount { get; set; } = false;
         public bool ImportUninstalledGames { get; set; } = false;

--- a/source/Libraries/SteamLibrary/SteamMetadataProvider.cs
+++ b/source/Libraries/SteamLibrary/SteamMetadataProvider.cs
@@ -56,7 +56,8 @@ namespace SteamLibrary
                 return new MetadataProvider(apiClient).GetGameMetadata(
                     gameId.AppID,
                     library.SettingsViewModel.Settings.BackgroundSource,
-                    library.SettingsViewModel.Settings.DownloadVerticalCovers);
+                    library.SettingsViewModel.Settings.DownloadVerticalCovers,
+                    library.SettingsViewModel.Settings.DownloadFallbackBannerCovers);
             }
         }
     }

--- a/source/Libraries/SteamLibrary/SteamShared/MetadataProvider.cs
+++ b/source/Libraries/SteamLibrary/SteamShared/MetadataProvider.cs
@@ -124,7 +124,8 @@ namespace Steam
         internal SteamGameMetadata DownloadGameMetadata(
             uint appId,
             BackgroundSource backgroundSource,
-            bool downloadVerticalCovers)
+            bool downloadVerticalCovers,
+            bool downloadFallbackBannerCovers)
         {
             var metadata = new SteamGameMetadata();
             var productInfo = GetAppInfo(appId);
@@ -175,7 +176,7 @@ namespace Steam
                 }
             }
 
-            // Image
+            // Cover Image
             var useBanner = false;
             if (downloadVerticalCovers)
             {
@@ -185,7 +186,7 @@ namespace Steam
                 {
                     metadata.CoverImage = new MetadataFile(imageUrl);
                 }
-                else
+                else if (downloadFallbackBannerCovers)
                 {
                     useBanner = true;
                 }
@@ -201,7 +202,7 @@ namespace Steam
                 }
             }
 
-            if (metadata.CoverImage == null)
+            if (metadata.CoverImage == null && downloadFallbackBannerCovers)
             {
                 if (productInfo != null)
                 {
@@ -268,9 +269,10 @@ namespace Steam
         public SteamGameMetadata GetGameMetadata(
             uint appId,
             BackgroundSource backgroundSource,
-            bool downloadVerticalCovers)
+            bool downloadVerticalCovers,
+            bool downloadFallbackBannerCovers)
         {
-            var metadata = DownloadGameMetadata(appId, backgroundSource, downloadVerticalCovers);
+            var metadata = DownloadGameMetadata(appId, backgroundSource, downloadVerticalCovers, downloadFallbackBannerCovers);
             metadata.Name = metadata.ProductDetails?["common"]["name"]?.Value ?? metadata.StoreDetails?.name;
             metadata.Links = new List<Link>()
             {

--- a/source/Localization/en_US.xaml
+++ b/source/Localization/en_US.xaml
@@ -35,6 +35,7 @@ Note that the Account Name option only works for accounts whose game libraries h
     <sys:String x:Key="LOCSteamLinksGuides">Guides</sys:String>
     <sys:String x:Key="LOCSteamLinksWorkshop">Workshop</sys:String>
     <sys:String x:Key="LOCSteamUseVerticalCovers">Download vertical cover images</sys:String>
+    <sys:String x:Key="LOCSteamDownloadFallbackBannerCovers">Download banner cover when vertical image could not be obtained</sys:String>
     <sys:String x:Key="LOCSteamImportFreeSubGames">Import generic free items</sys:String>
     <sys:String x:Key="LOCSettingsSteamCatImportWarn">This will overwrite current categories as well as hidden and favorite states on all Steam games. Do you want to continue?</sys:String>
     <sys:String x:Key="LOCSettingsSteamCatImportWarnTitle">Import Categories?</sys:String>

--- a/source/Metadata/UniversalSteamMetadata/UniversalSteamMetadataProvider.cs
+++ b/source/Metadata/UniversalSteamMetadata/UniversalSteamMetadataProvider.cs
@@ -255,7 +255,8 @@ namespace UniversalSteamMetadata
                     currentMetadata = metadataProvider.GetGameMetadata(
                         appId,
                         plugin.SettingsViewModel.Settings.BackgroundSource,
-                        plugin.SettingsViewModel.Settings.DownloadVerticalCovers);
+                        plugin.SettingsViewModel.Settings.DownloadVerticalCovers,
+                        plugin.SettingsViewModel.Settings.DownloadFallbackBannerCovers);
                 }
                 else
                 {
@@ -267,7 +268,8 @@ namespace UniversalSteamMetadata
                             currentMetadata = metadataProvider.GetGameMetadata(
                                 matchedId,
                                 plugin.SettingsViewModel.Settings.BackgroundSource,
-                                plugin.SettingsViewModel.Settings.DownloadVerticalCovers);
+                                plugin.SettingsViewModel.Settings.DownloadVerticalCovers,
+                                plugin.SettingsViewModel.Settings.DownloadFallbackBannerCovers);
                         }
                         else
                         {
@@ -319,7 +321,8 @@ namespace UniversalSteamMetadata
                             currentMetadata = metadataProvider.GetGameMetadata(
                                 ((StoreSearchResult)selectedGame).GameId,
                                 plugin.SettingsViewModel.Settings.BackgroundSource,
-                                plugin.SettingsViewModel.Settings.DownloadVerticalCovers);
+                                plugin.SettingsViewModel.Settings.DownloadVerticalCovers,
+                                plugin.SettingsViewModel.Settings.DownloadFallbackBannerCovers);
                         }
                     }
                 }

--- a/source/Metadata/UniversalSteamMetadata/UniversalSteamMetadataSettingsView.xaml
+++ b/source/Metadata/UniversalSteamMetadata/UniversalSteamMetadataSettingsView.xaml
@@ -18,8 +18,10 @@
     </UserControl.Resources>
 
     <StackPanel Margin="20">
-        <CheckBox Content="Use new vertical cover images"
+        <CheckBox Name="CheckUseVerticalCovers" Content="Use new vertical cover images"
                   IsChecked="{Binding Settings.DownloadVerticalCovers}" />
+        <CheckBox Content="Download banner cover when vertical image could not be obtained" IsEnabled="{Binding IsChecked, ElementName=CheckUseVerticalCovers}"
+                  IsChecked="{Binding Settings.DownloadFallbackBannerCovers}" Margin="40,10,0,5" />
 
         <TextBlock Text="Background image source:" VerticalAlignment="Center" Margin="0,10,0,10" />
 

--- a/source/Metadata/UniversalSteamMetadata/UniversalSteamMetadataSettingsViewModel.cs
+++ b/source/Metadata/UniversalSteamMetadata/UniversalSteamMetadataSettingsViewModel.cs
@@ -11,6 +11,7 @@ namespace UniversalSteamMetadata
     public class UniversalSteamMetadataSettings
     {
         public bool DownloadVerticalCovers { get; set; } = true;
+        public bool DownloadFallbackBannerCovers { get; set; } = false;
         public BackgroundSource BackgroundSource { get; set; } = BackgroundSource.Image;
     }
 


### PR DESCRIPTION
(There's no PR template in this repository)

Done for SteamLibrary and UniversalSteamMetadata plugins. Fixes https://github.com/JosefNemec/Playnite/issues/2198

Adds setting to configure if the extensions should fallback to download banner images if vertical images were not obtained. Built and tested in Playnite 9.