### PR TITLE
GOG: Fix in case user library stats data could not be obtained during library import or GOG profile has been disabled in privacy settings by user

### DIFF
--- a/source/Libraries/GogLibrary/GogLibrary.cs
+++ b/source/Libraries/GogLibrary/GogLibrary.cs
@@ -230,14 +230,16 @@ namespace GogLibrary
                 }
 
                 var libGamesStats = api.GetOwnedGames(api.GetAccountInfo());
-                if (libGamesStats == null)
+                if (libGamesStats != null)
                 {
-                    throw new Exception("Failed to obtain library stats data.");
+                    foreach (LibraryGameResponse libGame in libGames)
+                    {
+                        libGame.stats = libGamesStats?.FirstOrDefault(x => x.game.id.Equals(libGame.game.id))?.stats ?? null;
+                    }
                 }
-
-                foreach (LibraryGameResponse libGame in libGames)
+                else
                 {
-                    libGame.stats = libGamesStats?.FirstOrDefault(x => x.game.id.Equals(libGame.game.id))?.stats ?? null;
+                    Logger.Warn("Failed to obtain library stats data.");
                 }
 
                 return LibraryGamesToGames(libGames).ToList();


### PR DESCRIPTION
GOG: Fix in case user library stats data could not be obtained during library import or GOG profile has been disabled in privacy settings by user

Fixes https://github.com/JosefNemec/PlayniteExtensions/issues/66

![image](https://user-images.githubusercontent.com/1389286/135661254-f5069598-9d13-4516-8ed4-d7d065f090ce.png)


Edit: The actual cause of the issue was that the profile privacy was set to maximum and GOG returns a blank page for those profiles. While the issue is fixed, we need to see if there's a way to still get that data in those profiles

Edit 2: Nothing can be done about it. Disabling this option means not even you can access that data when logged in https://www.gog.com/account/settings/privacy

![image](https://user-images.githubusercontent.com/1389286/135681785-b365cc9d-e871-4a0e-aa7c-be57a512019d.png)
