### PR TITLE
RockstarGamesLibrary: Fix GTA V not being detected as installed after its latest update #69

### DIFF
--- a/source/Libraries/RockstarLibrary/RockstarGamesLibrary.cs
+++ b/source/Libraries/RockstarLibrary/RockstarGamesLibrary.cs
@@ -46,7 +46,7 @@ namespace RockstarGamesLibrary
                     var rsGame = RockstarGames.Games.FirstOrDefault(a => a.TitleId == titleId);
                     if (rsGame == null)
                     {
-                        logger.Warn($"Uknown Rockstar game with titleid {titleId}");
+                        logger.Warn($"Unknown Rockstar game with titleid {titleId}");
                         continue;
                     }
 

--- a/source/Libraries/RockstarLibrary/RockstarGamesLibrary.cs
+++ b/source/Libraries/RockstarLibrary/RockstarGamesLibrary.cs
@@ -39,7 +39,7 @@ namespace RockstarGamesLibrary
                     continue;
                 }
 
-                var match = Regex.Match(app.UninstallString, @"Launcher\.exe.+uninstall=(.+)$", RegexOptions.IgnoreCase);
+                var match = Regex.Match(app.UninstallString, @"(?:Launcher|uninstall)\.exe.+uninstall=(.+)$", RegexOptions.IgnoreCase);
                 if (match.Success)
                 {
                     var titleId = match.Groups[1].Value;


### PR DESCRIPTION
Fixes #69

Built and confirmed working

![image](https://user-images.githubusercontent.com/1389286/136071417-ff000b8f-6e44-47b9-b0c3-8914b2fd5c49.png)

