### PR TITLE
Add GTA Definitive editions to Rockstar extension

### DIFF
--- a/source/Libraries/RockstarLibrary/RockstartGames.cs
+++ b/source/Libraries/RockstarLibrary/RockstartGames.cs
@@ -59,12 +59,6 @@ namespace RockstarGamesLibrary
             },
             new RockstarGame
             {
-                Name = "Grand Theft Auto: San Andreas – The Definitive Edition",
-                Executable = "Gameface/Binaries/Win64/SanAndreas.exe",
-                TitleId = "gtasaunreal"
-            },
-            new RockstarGame
-            {
                 Name = "Grand Theft Auto III",
                 Executable = "gta3.exe",
                 TitleId = "gta3"
@@ -86,6 +80,24 @@ namespace RockstarGamesLibrary
                 Name = "Grand Theft Auto IV",
                 Executable = "GTAIV.exe",
                 TitleId = "gta4"
+            },
+            new RockstarGame
+            {
+                Name = "Grand Theft Auto III: The Definitive Edition",
+                Executable = "Gameface/Binaries/Win64/LibertyCity.exe",
+                TitleId = "gta3unreal"
+            },
+            new RockstarGame
+            {
+                Name = "Grand Theft Auto: Vice City – The Definitive Edition",
+                Executable = "Gameface/Binaries/Win64/ViceCity.exe",
+                TitleId = "gtavcunreal"
+            },
+            new RockstarGame
+            {
+                Name = "Grand Theft Auto: San Andreas – The Definitive Edition",
+                Executable = "Gameface/Binaries/Win64/SanAndreas.exe",
+                TitleId = "gtasaunreal"
             }
         };
 

--- a/source/Libraries/RockstarLibrary/RockstartGames.cs
+++ b/source/Libraries/RockstarLibrary/RockstartGames.cs
@@ -59,6 +59,12 @@ namespace RockstarGamesLibrary
             },
             new RockstarGame
             {
+                Name = "Grand Theft Auto: San Andreas – The Definitive Edition",
+                Executable = "Gameface/Binaries/Win64/SanAndreas.exe",
+                TitleId = "gtasaunreal"
+            },
+            new RockstarGame
+            {
                 Name = "Grand Theft Auto III",
                 Executable = "gta3.exe",
                 TitleId = "gta3"


### PR DESCRIPTION
I just bought the gta trilogy definitive editions from the Rockstar Launcher. Wanted to add the games to my Playnite game collection. 

I compiled the rockstar extension and tested it on my machine. I got all 3 games to show up as installed in Playnite, got metadata to download for each of the games, and hitting "Play" started each of the games successfully.  