### PR TITLE
RockstarGamesLibrary: Don't mark games as installed if installation d…

### DIFF
--- a/source/Libraries/RockstarLibrary/RockstarGamesLibrary.cs
+++ b/source/Libraries/RockstarLibrary/RockstarGamesLibrary.cs
@@ -51,16 +51,18 @@ namespace RockstarGamesLibrary
                     }
 
                     var isInstalled = true;
-                    if (!Directory.Exists(app.InstallLocation))
+                    var installDirectory = app.InstallLocation;
+                    if (!Directory.Exists(installDirectory))
                     {
-                        logger.Info($"Rockstar game {rsGame.Name} installation directory {app.InstallLocation} not detected.");
+                        logger.Info($"Rockstar game {rsGame.Name} installation directory {installDirectory} not detected.");
                         isInstalled = false;
+                        installDirectory = string.Empty;
                     }
 
                     var newGame = new GameMetadata
                     {
                         IsInstalled = isInstalled,
-                        InstallDirectory = app.InstallLocation,
+                        InstallDirectory = installDirectory,
                         Source = new MetadataNameProperty("Rockstar Games"),
                         Name = rsGame.Name,
                         GameId = titleId,

--- a/source/Libraries/RockstarLibrary/RockstarGamesLibrary.cs
+++ b/source/Libraries/RockstarLibrary/RockstarGamesLibrary.cs
@@ -50,9 +50,16 @@ namespace RockstarGamesLibrary
                         continue;
                     }
 
+                    var isInstalled = true;
+                    if (!Directory.Exists(app.InstallLocation))
+                    {
+                        logger.Info($"Rockstar game {rsGame.Name} installation directory {app.InstallLocation} not detected.");
+                        isInstalled = false;
+                    }
+
                     var newGame = new GameMetadata
                     {
-                        IsInstalled = true,
+                        IsInstalled = isInstalled,
                         InstallDirectory = app.InstallLocation,
                         Source = new MetadataNameProperty("Rockstar Games"),
                         Name = rsGame.Name,


### PR DESCRIPTION
Don't mark games as installed if installation directory is not detected. This change also makes it consistent with the Steam plugin that has the same behavior.