### PR TITLE
EpicLibrary: Don't mark games as installed if installation directory …

### DIFF
--- a/source/Libraries/EpicLibrary/EpicLibrary.cs
+++ b/source/Libraries/EpicLibrary/EpicLibrary.cs
@@ -69,6 +69,7 @@ namespace EpicLibrary
                 {
                     logger.Info($"Epic game {gameName} installation directory {installLocation} not detected.");
                     isInstalled = false;
+                    installLocation = string.Empty;
                 }
 
                 var game = new GameMetadata()

--- a/source/Libraries/EpicLibrary/EpicLibrary.cs
+++ b/source/Libraries/EpicLibrary/EpicLibrary.cs
@@ -62,8 +62,8 @@ namespace EpicLibrary
                     continue;
                 }
 
-                var installLocation = manifest?.InstallLocation ?? app.InstallLocation;
                 var gameName = manifest?.DisplayName ?? Path.GetFileName(app.InstallLocation);
+                var installLocation = manifest?.InstallLocation ?? app.InstallLocation;
                 var isInstalled = true;
                 if (!Directory.Exists(installLocation))
                 {

--- a/source/Libraries/EpicLibrary/EpicLibrary.cs
+++ b/source/Libraries/EpicLibrary/EpicLibrary.cs
@@ -19,6 +19,7 @@ namespace EpicLibrary
     [LoadPlugin]
     public class EpicLibrary : LibraryPluginBase<EpicLibrarySettingsViewModel>
     {
+        private static readonly ILogger logger = LogManager.GetLogger();
         internal readonly string TokensPath;
 
         public EpicLibrary(IPlayniteAPI api) : base(
@@ -61,13 +62,22 @@ namespace EpicLibrary
                     continue;
                 }
 
+                var installLocation = manifest?.InstallLocation ?? app.InstallLocation;
+                var gameName = manifest?.DisplayName ?? Path.GetFileName(app.InstallLocation);
+                var isInstalled = true;
+                if (!Directory.Exists(installLocation))
+                {
+                    logger.Info($"Epic game {gameName} installation directory {installLocation} not detected.");
+                    isInstalled = false;
+                }
+
                 var game = new GameMetadata()
                 {
                     Source = new MetadataNameProperty("Epic"),
                     GameId = app.AppName,
-                    Name = manifest?.DisplayName ?? Path.GetFileName(app.InstallLocation),
-                    InstallDirectory = manifest?.InstallLocation ?? app.InstallLocation,
-                    IsInstalled = true,
+                    Name = gameName,
+                    InstallDirectory = installLocation,
+                    IsInstalled = isInstalled,
                     Platforms = new HashSet<MetadataProperty> { new MetadataSpecProperty("pc_windows") }
                 };
 


### PR DESCRIPTION
EpicLibrary: Don't mark games as installed if installation directory is not detected

Helps to not mark games as installed if they are in a drive that is not currently connected.

Built and tested. I added a logger so this is registered when it happens and made some variables to not have to get them multiple times but it can be changed if necessary.

Example:
```
05-02 07:29:54.034|INFO |EpicLibrary#EpicLibrary:Epic game Hyper Light Drifter installation directory G:\Games\PC\Epic Games\HyperLightDrifter not detected.
05-02 07:29:54.034|INFO |EpicLibrary#EpicLibrary:Epic game Towerfall Ascension installation directory G:\Games\PC\Epic Games\TowerfallAscension not detected.
05-02 07:29:54.042|INFO |EpicLibrary#EpicLibrary:Epic game Twinmotion EDU 2020.2.3 installation directory C:\Software\Twinmotion2020.2EDU not detected.
05-02 07:29:54.042|INFO |EpicLibrary#EpicLibrary:Epic game The End is Nigh installation directory G:\Games\PC\Epic Games\TheEndIsNigh not detected.
05-02 07:29:54.042|DEBUG|EpicLibrary#EpicLibrary:Found 4 installed Epic games.
05-02 07:29:56.264|DEBUG|EpicLibrary#EpicLibrary:Found 280 library Epic games.
```