### PR TITLE
Humble fix isInstalled detection if game unavailable

### DIFF
--- a/source/Libraries/HumbleLibrary/HumbleLibrary.cs
+++ b/source/Libraries/HumbleLibrary/HumbleLibrary.cs
@@ -93,12 +93,9 @@ namespace HumbleLibrary
                 }
 
                 var installDir = Path.GetDirectoryName(exePath);
-                var isInstalled = true;
                 if (!Directory.Exists(installDir))
                 {
-                    Logger.Error($"{entry.gameName} installation directory {installDir} not detected.");
-                    installDir = string.Empty;
-                    isInstalled = false;
+                    continue;
                 }
 
                 games.Add(new InstalledTroveGame
@@ -107,7 +104,7 @@ namespace HumbleLibrary
                     GameId = entry.machineName,
                     InstallDirectory = installDir,
                     Executable = exePath,
-                    IsInstalled = isInstalled
+                    IsInstalled = true
                 });
             }
 
@@ -384,7 +381,7 @@ namespace HumbleLibrary
                 }
                 else
                 {
-                    var installed = GetInstalledGames().FirstOrDefault(a => a.GameId == args.Game.GameId && a.IsInstalled);
+                    var installed = GetInstalledGames().FirstOrDefault(a => a.GameId == args.Game.GameId);
                     if (installed != null)
                     {
                         yield return new AutomaticPlayController(args.Game)

--- a/source/Libraries/HumbleLibrary/HumbleLibrary.cs
+++ b/source/Libraries/HumbleLibrary/HumbleLibrary.cs
@@ -39,7 +39,6 @@ namespace HumbleLibrary
     [LoadPlugin]
     public class HumbleLibrary : LibraryPluginBase<HumbleLibrarySettingsViewModel>
     {
-        private static readonly ILogger logger = LogManager.GetLogger();
         public string UserAgent { get; }
 
         public HumbleLibrary(IPlayniteAPI api) : base(
@@ -97,7 +96,7 @@ namespace HumbleLibrary
                 var isInstalled = true;
                 if (!Directory.Exists(installDir))
                 {
-                    logger.Error($"{entry.gameName} installation directory {installDir} not detected.");
+                    Logger.Error($"{entry.gameName} installation directory {installDir} not detected.");
                     installDir = string.Empty;
                     isInstalled = false;
                 }

--- a/source/Libraries/HumbleLibrary/HumbleLibrary.cs
+++ b/source/Libraries/HumbleLibrary/HumbleLibrary.cs
@@ -384,7 +384,7 @@ namespace HumbleLibrary
                 }
                 else
                 {
-                    var installed = GetInstalledGames().FirstOrDefault(a => a.GameId == args.Game.GameId);
+                    var installed = GetInstalledGames().FirstOrDefault(a => a.GameId == args.Game.GameId && a.IsInstalled);
                     if (installed != null)
                     {
                         yield return new AutomaticPlayController(args.Game)

--- a/source/Libraries/HumbleLibrary/HumbleLibrary.cs
+++ b/source/Libraries/HumbleLibrary/HumbleLibrary.cs
@@ -39,6 +39,7 @@ namespace HumbleLibrary
     [LoadPlugin]
     public class HumbleLibrary : LibraryPluginBase<HumbleLibrarySettingsViewModel>
     {
+        private static readonly ILogger logger = LogManager.GetLogger();
         public string UserAgent { get; }
 
         public HumbleLibrary(IPlayniteAPI api) : base(
@@ -93,12 +94,21 @@ namespace HumbleLibrary
                 }
 
                 var installDir = Path.GetDirectoryName(exePath);
+                var isInstalled = true;
+                if (!Directory.Exists(installDir))
+                {
+                    logger.Error($"{entry.gameName} installation directory {installDir} not detected.");
+                    installDir = string.Empty;
+                    isInstalled = false;
+                }
+
                 games.Add(new InstalledTroveGame
                 {
                     Name = entry.gameName,
                     GameId = entry.machineName,
                     InstallDirectory = installDir,
-                    Executable = exePath
+                    Executable = exePath,
+                    IsInstalled = isInstalled
                 });
             }
 
@@ -279,7 +289,7 @@ namespace HumbleLibrary
                             var installed = installedGames.FirstOrDefault(a => a.GameId == troveGame.GameId);
                             if (installed != null)
                             {
-                                troveGame.IsInstalled = true;
+                                troveGame.IsInstalled = installed.IsInstalled;
                                 troveGame.InstallDirectory = installed.InstallDirectory;
                             }
 


### PR DESCRIPTION
Fix games incorrectly being marked as installed in cases where the detected game path is not currently available. Useful in cases where games are installed on an external usb that could be disconnected.

Built and tested.