### PR TITLE
Itch.io: Fix issue that old collections are imported instead of latest collections.

### DIFF
--- a/source/Libraries/ItchioLibrary/Butler.cs
+++ b/source/Libraries/ItchioLibrary/Butler.cs
@@ -360,8 +360,8 @@ namespace ItchioLibrary
             if (optionalParameters != null)
             {
                 foreach (var pair in optionalParameters)
-                { 
-                    prms.Add(pair.Key, pair.Value); 
+                {
+                    prms.Add(pair.Key, pair.Value);
                 }
             }
             var gameRecords = client.SendRequest<FetchGameRecords>(Methods.FetchGameRecords, prms);

--- a/source/Libraries/ItchioLibrary/Butler.cs
+++ b/source/Libraries/ItchioLibrary/Butler.cs
@@ -341,37 +341,49 @@ namespace ItchioLibrary
 
         public FetchCollections GetCollection(long id)
         {
-            return client.SendRequest<FetchCollections>(Methods.FetchCollections, new Dictionary<string, object>
+            var prms = new Dictionary<string, object>();
+            prms.Add("profileId",id);
+            var collections = client.SendRequest<FetchCollections>(Methods.FetchCollections, prms);
+            if (collections.stale)
             {
-                {"profileId",id }
-            });
+                prms.Add("fresh", true);
+                collections = client.SendRequest<FetchCollections>(Methods.FetchCollections, prms);
+            }
+            return collections;
         }
 
         public FetchGameRecords GetGameRecords(long id, string source, Dictionary<string, object> optionalParameters = null)
         {
-            var parameters = new Dictionary<string, object>
-            {
-                { "profileId",id },
-                { "source", source },
-            };
+            var prms = new Dictionary<string, object>();
+            prms.Add("profileId", id);
+            prms.Add("source", source);
             if (optionalParameters != null)
             {
                 foreach (var pair in optionalParameters)
-                {
-                    parameters.Add(pair.Key, pair.Value);
+                { 
+                    prms.Add(pair.Key, pair.Value); 
                 }
             }
-
-            return client.SendRequest<FetchGameRecords>(Methods.FetchGameRecords, parameters);
+            var gameRecords = client.SendRequest<FetchGameRecords>(Methods.FetchGameRecords, prms);
+            if (gameRecords.stale)
+            {
+                prms.Add("fresh", true);
+                gameRecords = client.SendRequest<FetchGameRecords>(Methods.FetchGameRecords, prms);
+            }
+            return gameRecords;
         }
 
         public ItchioGame GetGame(int gameId)
         {
-            return client.SendRequest<FetchGame>(Methods.Fetch_Game, new Dictionary<string, object>
+            var prms = new Dictionary<string, object>();
+            prms.Add("gameId", gameId);
+            var game = client.SendRequest<FetchGame>(Methods.Fetch_Game, prms);
+            if (game.stale)
             {
-                { "gameId", gameId },
-                { "fresh", true }
-            }).game;
+                prms.Add("fresh", true);
+                game = client.SendRequest<FetchGame>(Methods.Fetch_Game, prms);
+            }
+            return game.game;
         }
 
         public void Shutdown()
@@ -381,11 +393,15 @@ namespace ItchioLibrary
 
         public List<DownloadKey> GetOwnedKeys(long profileId)
         {
-            return client.SendRequest<FetchProfileOwnedKeys>(Methods.Fetch_ProfileOwnedKeys, new Dictionary<string, object>
+            var prms = new Dictionary<string, object>();
+            prms.Add("profileId", profileId);
+            var ownedKeys = client.SendRequest<FetchProfileOwnedKeys>(Methods.Fetch_ProfileOwnedKeys, prms);
+            if (ownedKeys.stale)
             {
-                { "profileId", profileId },
-                { "fresh", true }
-            }).items;
+                prms.Add("fresh", true);
+                ownedKeys = client.SendRequest<FetchProfileOwnedKeys>(Methods.Fetch_ProfileOwnedKeys, prms);
+            }
+            return ownedKeys.items;
         }
 
         public Task LaunchAsync(string caveId)

--- a/source/Libraries/ItchioLibrary/Models/FetchGameRecords.cs
+++ b/source/Libraries/ItchioLibrary/Models/FetchGameRecords.cs
@@ -9,5 +9,9 @@ namespace ItchioLibrary.Models
         /// Requested game records.
         /// </summary>
         public List<GameRecord> records;
+        /// <summary>
+        /// True if the info was from local DB and it should be re-queried using “Fresh”.
+        /// </summary>
+        public bool stale;
     }
 }

--- a/source/Libraries/ItchioLibrary/Models/FetchProfileOwnedKeys.cs
+++ b/source/Libraries/ItchioLibrary/Models/FetchProfileOwnedKeys.cs
@@ -49,5 +49,9 @@ namespace ItchioLibrary.Models
         /// Download keys fetched for profile
         /// </summary>
         public List<DownloadKey> items;
+        /// <summary>
+        /// True if the info was from local DB and it should be re-queried using “Fresh”.
+        /// </summary>
+        public bool stale;
     }
 }


### PR DESCRIPTION
It is caused by the local butler.db not being updated.
If the stale key is true in the query response, re-query with refresh key are required. 
I've modified the code to get the intended behavior. 

For importing owned games, the refresh key was fixed to true. 
But, I also modified the code to check the stale key and re-query.

I've built and tested this code and it's working as expected.

Thank you.