### PR TITLE
Fix itch metadata

### DIFF
--- a/source/Libraries/ItchioLibrary/ItchioMetadataProvider.cs
+++ b/source/Libraries/ItchioLibrary/ItchioMetadataProvider.cs
@@ -63,7 +63,11 @@ namespace ItchioLibrary
                 var gamePage = parser.Parse(gamePageSrc);
 
                 // Description
-                gameData.Description = gamePage.QuerySelector(".formatted_description").InnerHtml;
+                var descriptionElement = gamePage.QuerySelector(".formatted_description");
+                if (descriptionElement != null)
+                {
+                    gameData.Description = gamePage.QuerySelector(".formatted_description").InnerHtml;
+                }
 
                 // Background
                 var gameTheme = gamePage.QuerySelector("#game_theme").InnerHtml;

--- a/source/Libraries/ItchioLibrary/ItchioMetadataProvider.cs
+++ b/source/Libraries/ItchioLibrary/ItchioMetadataProvider.cs
@@ -134,6 +134,11 @@ namespace ItchioLibrary
                 }
             }
 
+            if (gameData.ReleaseDate == null && itchGame.publishedAt != null)
+            {
+                gameData.ReleaseDate = new ReleaseDate((DateTime)itchGame.publishedAt);
+            }
+
             return gameData;
         }
 


### PR DESCRIPTION
Fixes for the following issues:
- #97, the release date is optional and lot of titles do not have it, we can use published date as fallback (the published date is not available through scraping without an account, but it's available through butler);
- the description box may not exists (example: https://unknown-developer.itch.io/void).