### PR TITLE
Add support to launch Xbox app directly on game page when installing

### DIFF
--- a/source/Libraries/XboxLibrary/Models/AuthenticationData.cs
+++ b/source/Libraries/XboxLibrary/Models/AuthenticationData.cs
@@ -75,6 +75,13 @@ namespace XboxLibrary.Models
             public string developerName;
             public DateTime? releaseDate;
             public int? minAge;
+            public List<Availability> availabilities;
+        }
+
+        public class Availability
+        {
+            public List<string> Platforms;
+            public string ProductId;
         }
 
         public class Title

--- a/source/Libraries/XboxLibrary/XboxGameController.cs
+++ b/source/Libraries/XboxLibrary/XboxGameController.cs
@@ -17,11 +17,13 @@ namespace XboxLibrary
     public class XboxInstallController : InstallController
     {
         private readonly bool userXboxApp;
+        private readonly string productId;
         private CancellationTokenSource watcherToken;
 
-        public XboxInstallController(Game game, bool useXboxApp) : base(game)
+        public XboxInstallController(Game game, bool useXboxApp, string productId) : base(game)
         {
             this.userXboxApp = useXboxApp;
+            this.productId = productId;
             Name = useXboxApp ? "Install using Xbox app" : "Install using MS Store";
         }
 
@@ -35,7 +37,14 @@ namespace XboxLibrary
             Dispose();
             if (userXboxApp)
             {
-                Xbox.OpenXboxPassApp();
+                if (!productId.IsNullOrEmpty())
+                {
+                    ProcessStarter.StartUrl($"msxbox://game/?productId={productId}");
+                }
+                else
+                {
+                    Xbox.OpenXboxPassApp();
+                }
             }
             else
             {


### PR DESCRIPTION
Add support to launch Xbox app directly on game page when installing

Should be considered a draft and treated as an idea.

To launch the xbox app directly on the store page, you need the title productId, which the game object doesn't have. The ProductId is needed so an option is to change the Titles model to store and save all all the pc games data to a file that can later be used to retrieve the ProductId.