### PR TITLE
Start games with Rockstar Launcher using arguments

### DIFF
--- a/source/Libraries/RockstarLibrary/RockstarGamesController.cs
+++ b/source/Libraries/RockstarLibrary/RockstarGamesController.cs
@@ -129,13 +129,12 @@ namespace RockstarGamesLibrary
             Dispose();
             if (Directory.Exists(Game.InstallDirectory))
             {
-                stopWatch = Stopwatch.StartNew();
                 procMon = new ProcessMonitor();
                 procMon.TreeStarted += ProcMon_TreeStarted;
                 procMon.TreeDestroyed += Monitor_TreeDestroyed;
                 var rsApp = RockstarGames.Games.First(a => a.TitleId == Game.GameId);
-                ProcessStarter.StartProcess(Path.Combine(Game.InstallDirectory, rsApp.Executable));
-                StartRunningWatcher();
+                ProcessStarter.StartProcess(RockstarGames.ClientExecPath, $"-skipPatcherCheck -minmodeApp={rsApp.TitleId}");
+                procMon.WatchDirectoryProcesses(Game.InstallDirectory, false);
             }
             else
             {
@@ -145,19 +144,13 @@ namespace RockstarGamesLibrary
 
         private void ProcMon_TreeStarted(object sender, EventArgs args)
         {
+            stopWatch = Stopwatch.StartNew();
             InvokeOnStarted(new GameStartedEventArgs());
         }
 
         private void Monitor_TreeDestroyed(object sender, EventArgs args)
         {
             InvokeOnStopped(new GameStoppedEventArgs(Convert.ToUInt64(stopWatch.Elapsed.TotalSeconds)));
-        }
-
-        public async void StartRunningWatcher()
-        {
-            // Give original process some time to start RS launcher and then kill itself
-            await Task.Delay(10000);
-            procMon.WatchDirectoryProcesses(Game.InstallDirectory, false);
         }
     }
 }


### PR DESCRIPTION
Possibly fixes start detection and game tracking issues.

Works with GTAV and GTA San Andreas. Needs to be tested with more games.