### PR TITLE
Steam: Fix stopwatch being started before process is started

### DIFF
--- a/source/Libraries/SteamLibrary/SteamGameController.cs
+++ b/source/Libraries/SteamLibrary/SteamGameController.cs
@@ -167,7 +167,6 @@ namespace SteamLibrary
                 }
             }
 
-            stopWatch = Stopwatch.StartNew();
             ProcessStarter.StartUrl($"steam://rungameid/{Game.GameId}");
             procMon = new ProcessMonitor();
             procMon.TreeStarted += ProcMon_TreeStarted;
@@ -184,6 +183,7 @@ namespace SteamLibrary
 
         private void ProcMon_TreeStarted(object sender, EventArgs args)
         {
+            stopWatch = Stopwatch.StartNew();
             InvokeOnStarted(new GameStartedEventArgs());
         }
 


### PR DESCRIPTION
Steam: Fix stopwatch being started before process is started

It makes more sense to start the stopwatch only after the game process has been detected as running as this will provide a more accurate Playtime.

Built and tested