### PR TITLE
Changes authorization method for Epic to authorization_code based

### DIFF
--- a/source/Libraries/EpicLibrary/Services/EpicAccountClient.cs
+++ b/source/Libraries/EpicLibrary/Services/EpicAccountClient.cs
@@ -29,6 +29,7 @@ namespace EpicLibrary.Services
     {
         public string redirectUrl { get; set; }
         public string sid { get; set; }
+        public string authorizationCode { get; set; }
     }
 
     public class EpicAccountClient
@@ -36,7 +37,7 @@ namespace EpicLibrary.Services
         private ILogger logger = LogManager.GetLogger();
         private IPlayniteAPI api;
         private string tokensPath;
-        private readonly string loginUrl = "https://www.epicgames.com/id/login?redirectUrl=https://www.epicgames.com/id/api/redirect";
+        private readonly string loginUrl = "https://www.epicgames.com/id/login?redirectUrl=https%3A//www.epicgames.com/id/api/redirect%3FclientId%3D34a02cf8f4414e29b15921876da36f9a%26responseType%3Dcode";
         private readonly string oauthUrl = @"";
         private readonly string accountUrl = @"";
         private readonly string assetsUrl = @"";
@@ -123,10 +124,9 @@ namespace EpicLibrary.Services
                 return;
             }
 
-            var sid = Serialization.FromJson<ApiRedirectResponse>(apiRedirectContent).sid;
+            var authorizationCode = Serialization.FromJson<ApiRedirectResponse>(apiRedirectContent).authorizationCode;
             FileSystem.DeleteFile(tokensPath);
-            var exchangeKey = getExchangeToken(sid);
-            if (string.IsNullOrEmpty(exchangeKey))
+            if (string.IsNullOrEmpty(authorizationCode))
             {
                 logger.Error("Failed to get login exchange key for Epic account.");
                 return;
@@ -136,7 +136,7 @@ namespace EpicLibrary.Services
             {
                 httpClient.DefaultRequestHeaders.Clear();
                 httpClient.DefaultRequestHeaders.Add("Authorization", "basic " + authEncodedString);
-                using (var content = new StringContent($"grant_type=exchange_code&exchange_code={exchangeKey}&token_type=eg1"))
+                using (var content = new StringContent($"grant_type=authorization_code&code={authorizationCode}&token_type=eg1"))
                 {
                     content.Headers.Clear();
                     content.Headers.Add("Content-Type", "application/x-www-form-urlencoded");


### PR DESCRIPTION
Hiya!

I've managed to fix Epic authentication by changing it to `authorization_code` based.
It includes a different `loginUrl` (specifically the redirection parameter), which is now returning code directly. `clientId` parameter in the URL is username taken from `authEncodedString` (as on the screenshot). Since `authorization_code` is delivered directly, `getExchangeToken` is no longer needed. I didn't delete the method, just skipped the call.

Everything seems to be working fine - I've cleared out tokens.json file, cleared cache, re-authorized with Epic successfully and all my games were imported, both installed and non-installed.

![image](https://user-images.githubusercontent.com/6712823/188267096-753f55ea-1776-4d6a-bb78-2a4f1d6f6dfe.png)

Fixes: https://github.com/JosefNemec/PlayniteExtensions/issues/207 https://github.com/JosefNemec/Playnite/issues/3039 https://github.com/JosefNemec/Playnite/issues/3038 https://github.com/JosefNemec/Playnite/issues/3036 https://www.reddit.com/r/playnite/comments/x2ex2j/unable_to_authenticate_epic_games/ https://playnite.link/forum/thread-1332.html https://playnite.link/forum/thread-1334.html 