### PR TITLE
Get Steam metadata for demos from the main game

### DIFF
--- a/source/Libraries/SteamLibrary/SteamShared/MetadataProvider.cs
+++ b/source/Libraries/SteamLibrary/SteamShared/MetadataProvider.cs
@@ -471,19 +471,20 @@ namespace Steam
             if (uint.TryParse(parentStr, out uint parentId))
             {
                 var parentMetadata = GetGameMetadata(parentId, backgroundSource, downloadVerticalCovers);
-                parentMetadata.GameId = metadata.GameId;
-                parentMetadata.Name = metadata.Name;
-                parentMetadata.Features = metadata.Features;
-                parentMetadata.ReleaseDate = metadata.ReleaseDate;
-                if (metadata.CoverImage.HasContent)
+
+                metadata.Links = parentMetadata.Links; //demo appId urls either redirect to the main game or are broken
+                metadata.CoverImage = metadata.CoverImage ?? parentMetadata.CoverImage;
+                metadata.BackgroundImage = metadata.BackgroundImage ?? parentMetadata.BackgroundImage;
+
+                if (string.IsNullOrWhiteSpace(metadata.Description))
                 {
-                    parentMetadata.CoverImage = metadata.CoverImage;
+                    metadata.Description = parentMetadata.Description;
                 }
-                if (metadata.BackgroundImage.HasContent)
+
+                if (metadata.Tags == null || metadata.Tags.Count == 0)
                 {
-                    parentMetadata.BackgroundImage = metadata.BackgroundImage;
+                    metadata.Tags = parentMetadata.Tags;
                 }
-                return parentMetadata;
             }
 
             return metadata;

--- a/source/Libraries/SteamLibrary/SteamShared/MetadataProvider.cs
+++ b/source/Libraries/SteamLibrary/SteamShared/MetadataProvider.cs
@@ -466,6 +466,26 @@ namespace Steam
                 }
             }
 
+            string parentStr = metadata.ProductDetails?["common"]["parent"]?.Value;
+
+            if (uint.TryParse(parentStr, out uint parentId))
+            {
+                var parentMetadata = GetGameMetadata(parentId, backgroundSource, downloadVerticalCovers);
+                parentMetadata.GameId = metadata.GameId;
+                parentMetadata.Name = metadata.Name;
+                parentMetadata.Features = metadata.Features;
+                parentMetadata.ReleaseDate = metadata.ReleaseDate;
+                if (metadata.CoverImage.HasContent)
+                {
+                    parentMetadata.CoverImage = metadata.CoverImage;
+                }
+                if (metadata.BackgroundImage.HasContent)
+                {
+                    parentMetadata.BackgroundImage = metadata.BackgroundImage;
+                }
+                return parentMetadata;
+            }
+
             return metadata;
         }
 


### PR DESCRIPTION
Steam demos don't get descriptions or tags. This will fix that (once the other PR for the is merged for the tags).