### PR TITLE
GOG: Start Galaxy minimized when launching games

### DIFF
--- a/source/Libraries/GogLibrary/GogLibrary.cs
+++ b/source/Libraries/GogLibrary/GogLibrary.cs
@@ -81,7 +81,7 @@ namespace GogLibrary
                     TrackingMode = TrackingMode.Directory,
                     Name = ResourceProvider.GetString(LOC.GOGStartUsingClient).Format("Galaxy"),
                     TrackingPath = installEntry.InstallDirectory,
-                    Arguments = string.Format(@"/gameId={0} /command=runGame /path=""{1}""", args.Game.GameId, installEntry.InstallDirectory),
+                    Arguments = string.Format(@"/launchViaAutostart /gameId={0} /command=runGame /path=""{1}""", args.Game.GameId, installEntry.InstallDirectory),
                     Path = Gog.ClientInstallationPath
                 };
             }


### PR DESCRIPTION
I think it makes more sense to not display the Galaxy client maximized when starting games. It also makes it more consistent with the UX with other clients and plugins like Steam, etc.

Tested and working.