### PR TITLE
Steam: Added platform metadata

### DIFF
--- a/source/Libraries/SteamLibrary/SteamShared/MetadataProvider.cs
+++ b/source/Libraries/SteamLibrary/SteamShared/MetadataProvider.cs
@@ -355,6 +355,30 @@ namespace Steam
                 {
                     metadata.Genres = metadata.StoreDetails.genres.Select(a => new MetadataNameProperty(a.description)).Cast<MetadataProperty>().ToHashSet();
                 }
+
+                if (metadata.StoreDetails.platforms != null)
+                {
+                    metadata.Platforms = new HashSet<MetadataProperty>();
+
+                    if (metadata.StoreDetails.platforms.windows)
+                    {
+                        metadata.Platforms.Add(new MetadataSpecProperty("pc_windows"));
+                    }
+
+                    if (metadata.StoreDetails.platforms.mac)
+                    {
+                        metadata.Platforms.Add(new MetadataSpecProperty("macintosh"));
+                    }
+
+                    if (metadata.StoreDetails.platforms.linux)
+                    {
+                        metadata.Platforms.Add(new MetadataSpecProperty("pc_linux"));
+                    }
+                }
+                else
+                {
+                    metadata.Platforms = new HashSet<MetadataProperty> { new MetadataSpecProperty("pc_windows") };
+                }
             }
 
             if (metadata.ProductDetails != null)

--- a/source/Metadata/UniversalSteamMetadata/UniversalSteamMetadataProvider.cs
+++ b/source/Metadata/UniversalSteamMetadata/UniversalSteamMetadataProvider.cs
@@ -257,7 +257,8 @@ namespace UniversalSteamMetadata
 
         public override IEnumerable<MetadataProperty> GetPlatforms(GetMetadataFieldArgs args)
         {
-            return new HashSet<MetadataProperty> { new MetadataSpecProperty("pc_windows") };
+            GetGameData();
+            return currentMetadata?.Platforms ?? base.GetPlatforms(args);
         }
 
         public override IEnumerable<MetadataProperty> GetTags(GetMetadataFieldArgs args)


### PR DESCRIPTION
Also fixes canceling out of manual metadata search resulting in a metadata assignment choice window with a pc_windows platform