### PR TITLE
Sets the process ID of the launched games in the GameStartedEventArgs…

### DIFF
--- a/source/Libraries/BattleNetLibrary/BattleNetGameController.cs
+++ b/source/Libraries/BattleNetLibrary/BattleNetGameController.cs
@@ -229,7 +229,7 @@ namespace BattleNetLibrary
         private void ProcMon_TreeStarted(object sender, ProcessMonitor.TreeStartedEventArgs args)
         {
             stopWatch = Stopwatch.StartNew();
-            InvokeOnStarted(new GameStartedEventArgs());
+            InvokeOnStarted(new GameStartedEventArgs() { StartedProcessId = args.StartedId });
         }
 
         private void Monitor_TreeDestroyed(object sender, EventArgs args)

--- a/source/Libraries/BattleNetLibrary/BattleNetLibrary.csproj
+++ b/source/Libraries/BattleNetLibrary/BattleNetLibrary.csproj
@@ -34,8 +34,8 @@
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Playnite.SDK, Version=6.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\PlayniteSDK.6.0.0\lib\net462\Playnite.SDK.dll</HintPath>
+    <Reference Include="Playnite.SDK">
+      <HintPath>..\..\packages\PlayniteSDK.6.4.0\lib\net462\Playnite.SDK.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/source/Libraries/OriginLibrary/OriginGameController.cs
+++ b/source/Libraries/OriginLibrary/OriginGameController.cs
@@ -230,7 +230,7 @@ namespace OriginLibrary
         private void ProcMon_TreeStarted(object sender, ProcessMonitor.TreeStartedEventArgs args)
         {
             stopWatch = Stopwatch.StartNew();
-            InvokeOnStarted(new GameStartedEventArgs());
+            InvokeOnStarted(new GameStartedEventArgs() { StartedProcessId = args.StartedId });
         }
 
         private void ProcMon_TreeDestroyed(object sender, EventArgs args)

--- a/source/Libraries/OriginLibrary/OriginLibrary.csproj
+++ b/source/Libraries/OriginLibrary/OriginLibrary.csproj
@@ -34,8 +34,8 @@
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Playnite.SDK, Version=6.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\PlayniteSDK.6.0.0\lib\net462\Playnite.SDK.dll</HintPath>
+    <Reference Include="Playnite.SDK">
+      <HintPath>..\..\packages\PlayniteSDK.6.4.0\lib\net462\Playnite.SDK.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/source/Libraries/RockstarLibrary/RockstarGamesController.cs
+++ b/source/Libraries/RockstarLibrary/RockstarGamesController.cs
@@ -144,7 +144,7 @@ namespace RockstarGamesLibrary
         private void ProcMon_TreeStarted(object sender, ProcessMonitor.TreeStartedEventArgs args)
         {
             stopWatch = Stopwatch.StartNew();
-            InvokeOnStarted(new GameStartedEventArgs());
+            InvokeOnStarted(new GameStartedEventArgs() { StartedProcessId = args.StartedId });
         }
 
         private void Monitor_TreeDestroyed(object sender, EventArgs args)

--- a/source/Libraries/RockstarLibrary/RockstarGamesLibrary.csproj
+++ b/source/Libraries/RockstarLibrary/RockstarGamesLibrary.csproj
@@ -34,8 +34,8 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Playnite.SDK, Version=6.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\PlayniteSDK.6.0.0\lib\net462\Playnite.SDK.dll</HintPath>
+    <Reference Include="Playnite.SDK">
+      <HintPath>..\..\packages\PlayniteSDK.6.4.0\lib\net462\Playnite.SDK.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/source/Libraries/SteamLibrary/SteamGameController.cs
+++ b/source/Libraries/SteamLibrary/SteamGameController.cs
@@ -196,7 +196,7 @@ namespace SteamLibrary
         private void ProcMon_TreeStarted(object sender, ProcessMonitor.TreeStartedEventArgs args)
         {
             stopWatch = Stopwatch.StartNew();
-            InvokeOnStarted(new GameStartedEventArgs());
+            InvokeOnStarted(new GameStartedEventArgs() { StartedProcessId = args.StartedId });
         }
 
         private void Monitor_TreeDestroyed(object sender, EventArgs args)

--- a/source/Libraries/SteamLibrary/SteamLibrary.csproj
+++ b/source/Libraries/SteamLibrary/SteamLibrary.csproj
@@ -37,8 +37,8 @@
     <Reference Include="Microsoft.Xaml.Behaviors, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Xaml.Behaviors.Wpf.1.1.39\lib\net45\Microsoft.Xaml.Behaviors.dll</HintPath>
     </Reference>
-    <Reference Include="Playnite.SDK, Version=6.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\PlayniteSDK.6.0.0\lib\net462\Playnite.SDK.dll</HintPath>
+    <Reference Include="Playnite.SDK">
+      <HintPath>..\..\packages\PlayniteSDK.6.4.0\lib\net462\Playnite.SDK.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/source/Libraries/UplayLibrary/UplayGameController.cs
+++ b/source/Libraries/UplayLibrary/UplayGameController.cs
@@ -177,7 +177,7 @@ namespace UplayLibrary
         private void ProcMon_TreeStarted(object sender, ProcessMonitor.TreeStartedEventArgs args)
         {
             stopWatch = Stopwatch.StartNew();
-            InvokeOnStarted(new GameStartedEventArgs());
+            InvokeOnStarted(new GameStartedEventArgs() { StartedProcessId = args.StartedId });
         }
 
         private void Monitor_TreeDestroyed(object sender, EventArgs args)

--- a/source/Libraries/UplayLibrary/UplayLibrary.csproj
+++ b/source/Libraries/UplayLibrary/UplayLibrary.csproj
@@ -34,8 +34,8 @@
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Playnite.SDK, Version=6.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\PlayniteSDK.6.0.0\lib\net462\Playnite.SDK.dll</HintPath>
+    <Reference Include="Playnite.SDK">
+      <HintPath>..\..\packages\PlayniteSDK.6.4.0\lib\net462\Playnite.SDK.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/source/Libraries/XboxLibrary/XboxGameController.cs
+++ b/source/Libraries/XboxLibrary/XboxGameController.cs
@@ -166,10 +166,10 @@ namespace XboxLibrary
             }
         }
 
-        private void ProcMon_TreeStarted(object sender, ProcessMonitor.TreeStartedEventArgs e)
+        private void ProcMon_TreeStarted(object sender, ProcessMonitor.TreeStartedEventArgs args)
         {
             stopWatch = Stopwatch.StartNew();
-            InvokeOnStarted(new GameStartedEventArgs());
+            InvokeOnStarted(new GameStartedEventArgs() { StartedProcessId = args.StartedId });
         }
 
         private void Monitor_TreeDestroyed(object sender, EventArgs args)

--- a/source/Libraries/XboxLibrary/XboxLibrary.csproj
+++ b/source/Libraries/XboxLibrary/XboxLibrary.csproj
@@ -34,8 +34,8 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Playnite.SDK, Version=6.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\PlayniteSDK.6.0.0\lib\net462\Playnite.SDK.dll</HintPath>
+    <Reference Include="Playnite.SDK">
+      <HintPath>..\..\packages\PlayniteSDK.6.4.0\lib\net462\Playnite.SDK.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />


### PR DESCRIPTION
**Description**
I need access to the process ID of the launched game, so I added it for of the libraries.

**Outstanding Issues**
There was at least one library -- specifically Itch.io -- which is structured differently, so that is unchanged.

There are also a few libraries which don't have a `PlayController` override, so I assume these already work fine. Epic games at least does from my own testing

**Testing Performed**
I created a powershell script to generate a windows notification with the process ID of the launched game. I then launched a game for to verify that the process against the process ID in task manager. I tested with games from the following libraries:
* EA App
* Ubisoft Connect
* Steam
* Xbox
* Epic (although this isn't technically part of my changes)

Notably, I did not test Battle.net and Rockstar Games because I don't have a game from those launchers to test with. But based on the above, I have no reason to think they wouldn't work.