### PR TITLE
Steam: removed Windows platform default to allow metadata provider to set platforms correctly

### DIFF
--- a/source/Libraries/SteamLibrary/SteamLibrary.cs
+++ b/source/Libraries/SteamLibrary/SteamLibrary.cs
@@ -165,7 +165,6 @@ namespace SteamLibrary
                 Name = name.RemoveTrademarks(),
                 InstallDirectory = installDir,
                 IsInstalled = true,
-                Platforms = new HashSet<MetadataProperty> { new MetadataSpecProperty("pc_windows") }
             };
 
             return game;
@@ -517,7 +516,6 @@ namespace SteamLibrary
                     Source = new MetadataNameProperty("Steam"),
                     Name = game.name.RemoveTrademarks(),
                     GameId = game.appid.ToString(),
-                    Platforms = new HashSet<MetadataProperty> { new MetadataSpecProperty("pc_windows") }
                 };
 
                 if (includePlayTime)
@@ -702,7 +700,6 @@ namespace SteamLibrary
                     Categories = appData.Select(a => new MetadataNameProperty(a)).Cast<MetadataProperty>().ToHashSet(),
                     Hidden = app["hidden"].AsInteger() == 1,
                     Favorite = isFavorite,
-                    Platforms = new HashSet<MetadataProperty> { new MetadataSpecProperty("pc_windows") }
                 });
             }
 


### PR DESCRIPTION
Before this, the platforms list would be filled with `pc_windows` by default, which would block platforms like `pc_linux` being set for newly imported games