### PR TITLE
Fix detection of some Half-Life mods in Steam Library Integration

### DIFF
--- a/source/Libraries/SteamLibrary/ModInfo.cs
+++ b/source/Libraries/SteamLibrary/ModInfo.cs
@@ -195,6 +195,10 @@ namespace SteamLibrary
                         {
                             modInfo.Links.Add(new Link("Manual", match.Groups[2].Value));
                         }
+                        else if (match.Groups[1].Value == "developer")
+                        {
+                            modInfo.Developer = match.Groups[2].Value;
+                        }
                         else if (match.Groups[1].Value == "developer_url")
                         {
                             modInfo.Links.Add(new Link("Developer URL", match.Groups[2].Value));

--- a/source/Libraries/SteamLibrary/ModInfo.cs
+++ b/source/Libraries/SteamLibrary/ModInfo.cs
@@ -123,6 +123,12 @@ namespace SteamLibrary
 
         static private uint GetModFolderCRC(string folder)
         {
+            int lastDotPos = folder.LastIndexOf('.');
+            if (lastDotPos != -1)
+            {
+                folder = folder.Substring(0, lastDotPos);
+            }
+
             uint crc = BitConverter.ToUInt32(CryptoHelper.CRCHash(Encoding.ASCII.GetBytes(folder)), 0);
 
             // For mods and shortcut game IDs, the high bit is always set. SteamKit doesn't do this automatically (yet).

--- a/source/Libraries/SteamLibrary/ModInfo.cs
+++ b/source/Libraries/SteamLibrary/ModInfo.cs
@@ -1,11 +1,10 @@
-﻿using System;
+﻿using Playnite.SDK.Models;
+using SteamKit2;
+using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
-using Playnite.SDK.Models;
-using SteamKit2;
 
 namespace SteamLibrary
 {
@@ -26,7 +25,7 @@ namespace SteamLibrary
         public string IconPath { get; private set; }
         private readonly ModType modType;
 
-        static private Dictionary<ModType, string> infoFileName = new Dictionary<ModType, string>()
+        static private  readonly Dictionary<ModType, string> infoFileName = new Dictionary<ModType, string>()
         {
             { ModType.HL, "liblist.gam"},
             { ModType.HL2, "gameinfo.txt"}
@@ -131,7 +130,7 @@ namespace SteamLibrary
 
             uint crc = BitConverter.ToUInt32(CryptoHelper.CRCHash(Encoding.ASCII.GetBytes(folder)), 0);
 
-            // For mods and shortcut game IDs, the high bit is always set. SteamKit doesn't do this automatically (yet).
+            // For mods and shortcut game IDs, the high bit is always set. SteamKit doesn't do this automatically prior to v2.2.0.
             crc |= 0x80000000;
 
             return crc;

--- a/source/Libraries/SteamLibrary/SteamLibrary.cs
+++ b/source/Libraries/SteamLibrary/SteamLibrary.cs
@@ -1,30 +1,21 @@
-﻿using Playnite.SDK;
+﻿using Playnite.Common;
+using Playnite.SDK;
+using Playnite.SDK.Data;
 using Playnite.SDK.Models;
 using Playnite.SDK.Plugins;
+using SteamKit2;
 using SteamLibrary.Models;
 using SteamLibrary.Services;
-using SteamKit2;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
 using System.Text;
-using System.Text.RegularExpressions;
-using System.Threading;
-using System.Threading.Tasks;
-using System.Windows.Controls;
-using Playnite;
 using System.Windows;
-using System.Reflection;
-using System.Collections.ObjectModel;
-using Playnite.Common.Web;
-using Steam;
-using System.Diagnostics;
-using Playnite.SDK.Data;
+using System.Windows.Controls;
 using System.Windows.Media;
-using Playnite.Common;
 
 namespace SteamLibrary
 {

--- a/source/Libraries/SteamLibrary/SteamLibrary.cs
+++ b/source/Libraries/SteamLibrary/SteamLibrary.cs
@@ -63,6 +63,8 @@ namespace SteamLibrary
         internal SteamServicesClient ServicesClient;
         internal TopPanelItem TopPanelFriendsButton;
 
+        private static readonly string[] firstPartyModPrefixes = new string[] { "bshift", "cstrike", "czero", "dmc", "dod", "gearbox", "ricochet", "tfc", "valve" };
+
         public SteamLibrary(IPlayniteAPI api) : base(
             "Steam",
             Guid.Parse("CB91DFC9-B977-43BF-8E70-55F46E410FAB"),
@@ -211,10 +213,9 @@ namespace SteamLibrary
         internal static List<GameMetadata> GetInstalledGoldSrcModsFromFolder(string path)
         {
             var games = new List<GameMetadata>();
-            var firstPartyMods = new string[] { "bshift", "cstrike", "czero", "czeror", "dmc", "dod", "gearbox", "ricochet", "tfc", "valve" };
             var dirInfo = new DirectoryInfo(path);
 
-            foreach (var folder in dirInfo.GetDirectories().Where(a => !firstPartyMods.Contains(a.Name)).Select(a => a.FullName))
+            foreach (var folder in dirInfo.GetDirectories().Where(a => !firstPartyModPrefixes.Any(prefix => a.Name.StartsWith(prefix))).Select(a => a.FullName))
             {
                 try
                 {


### PR DESCRIPTION
This was prompted by a user in Discord having a problem with a specific Half-Life mod being detected by the Steam Library Integration extension. After moving past a couple of red herrings that made it seem like mod detection was broken by a recent Steam update, I narrowed down the issue.

With the specific mod in question, the folder name is `Residual_Life_pub1.9`, but in SteamUI, `V_FileBase` is used to trim to just `Residual_Life_pub1` when generating the CGameID. This change fixes that.

I also noticed a different between how the extension and SteamUI each handle first-party mod exclusions (as they have discrete app IDs and are detected as regular, owned games). We have a hardcoded list, similar to one inside of SteamUI, but ours has more entries. This was because they use their list as a prefix check rather than whole string match. I changed that to better match as well, also removing `czeror` from our list as it's covered by the `czero` prefix.

Lastly, I saw that HL mods support a `developer` field in `liblist.gam`. Support for populating the Developer field in Playnite for these has been hooked up as well.