### PR TITLE
GOG: Remove sale promos from game descriptions

### DIFF
--- a/source/Libraries/GogLibrary/GOGMetadataProvider.cs
+++ b/source/Libraries/GogLibrary/GOGMetadataProvider.cs
@@ -172,7 +172,6 @@ namespace GogLibrary
             // Remove initial opening element and return description without promo
             document.Body.RemoveChild(firstChild);
             return document.Body.InnerHtml;
-
         }
     }
 }

--- a/source/Libraries/GogLibrary/GOGMetadataProvider.cs
+++ b/source/Libraries/GogLibrary/GOGMetadataProvider.cs
@@ -146,7 +146,7 @@ namespace GogLibrary
             }
 
             // It's possible to check if a description has a promo if they contain known promo image urls
-            if (!Regex.IsMatch(originalDescription, @"<img src=""https:\/\/items.gog.com\/(promobanners|autumn|fall|summer|winter)\/"))
+            if (!Regex.IsMatch(originalDescription, @"<img src=""https:\/\/items.gog.com\/(promobanners|autumn|fall|summer|winter)\/", RegexOptions.IgnoreCase))
             {
                 return originalDescription;
             }

--- a/source/Libraries/GogLibrary/GogLibrary.csproj
+++ b/source/Libraries/GogLibrary/GogLibrary.csproj
@@ -34,6 +34,9 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="AngleSharp, Version=0.9.9.0, Culture=neutral, PublicKeyToken=e83494dcdc6d31ea, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AngleSharp.0.9.9\lib\net45\AngleSharp.dll</HintPath>
+    </Reference>
     <Reference Include="Playnite.SDK, Version=6.4.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\PlayniteSDK.6.4.0\lib\net462\Playnite.SDK.dll</HintPath>
     </Reference>

--- a/source/Libraries/GogLibrary/packages.config
+++ b/source/Libraries/GogLibrary/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="AngleSharp" version="0.9.9" targetFramework="net462" />
   <package id="PlayniteSDK" version="6.4.0" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
Removes garbage promotional section that GOG adds to all game descriptions during sale periods.

Built and tested.