### PR TITLE
ItchioLibrary: Remove covers import during library update

### DIFF
--- a/source/Libraries/ItchioLibrary/ItchioLibrary.cs
+++ b/source/Libraries/ItchioLibrary/ItchioLibrary.cs
@@ -115,7 +115,6 @@ namespace ItchioLibrary
                         Name = cave.game.title.RemoveTrademarks(),
                         InstallDirectory = installDir,
                         IsInstalled = true,
-                        CoverImage = cave.game.coverUrl.IsNullOrEmpty() ? null : new MetadataFile(cave.game.coverUrl),
                         Platforms = new HashSet<MetadataProperty> { new MetadataSpecProperty("pc_windows") }
                     };
                     if (cave.game.publishedAt != null)
@@ -191,7 +190,6 @@ namespace ItchioLibrary
                                     Source = new MetadataNameProperty("itch.io"),
                                     GameId = game.id.ToString(),
                                     Name = game.title.RemoveTrademarks(),
-                                    CoverImage = game.coverUrl.IsNullOrEmpty() ? null : new MetadataFile(game.coverUrl),
                                     Platforms = new HashSet<MetadataProperty> { new MetadataSpecProperty("pc_windows") }
                                 };
                                 if (game.publishedAt != null)
@@ -231,7 +229,6 @@ namespace ItchioLibrary
                             Source = new MetadataNameProperty("itch.io"),
                             GameId = key.game.id.ToString(),
                             Name = key.game.title.RemoveTrademarks(),
-                            CoverImage = key.game.coverUrl.IsNullOrEmpty() ? null : new MetadataFile(key.game.coverUrl),
                             Platforms = new HashSet<MetadataProperty> { new MetadataSpecProperty("pc_windows") }
                         };
                         if (key.game.publishedAt != null)


### PR DESCRIPTION
Currently the extension sets game covers during library update. This will causes these issues:

- It will set a cover that could not have the aspect ratio and resolution desired by the user
- Because the cover is already set during import, metadata download after library update will skip fetching the Cover Image using the configured preferences of the user in `Metadata` settings and the game original, undesired cover will remain, requiring the user to manually start metadata download afterwards to fix it

In my opinion removing them is better and the image that the itchio plugin would have set, could still be obtained using the `Official Store` metadata download choice.