### PR TITLE
Steam Metadata: Fix incorrect searches when search has special characters

### DIFF
--- a/source/Metadata/UniversalSteamMetadata/UniversalSteamMetadata.cs
+++ b/source/Metadata/UniversalSteamMetadata/UniversalSteamMetadata.cs
@@ -71,7 +71,7 @@ namespace UniversalSteamMetadata
             var results = new List<StoreSearchResult>();
             using (var webClient = new WebClient { Encoding = Encoding.UTF8 })
             {
-                var searchPageSrc = webClient.DownloadString(string.Format(searchUrl, searchTerm));
+                var searchPageSrc = webClient.DownloadString(string.Format(searchUrl, Uri.EscapeDataString(searchTerm)));
                 var parser = new HtmlParser();
                 var searchPage = parser.Parse(searchPageSrc);
                 foreach (var gameElem in searchPage.QuerySelectorAll(".search_result_row"))


### PR DESCRIPTION
Currently the search uses the search term as it is and for games like `Command & Conquer Remastered Collection` that have characters that need encoding, like `&`,  `=`,  `?`, etc. this causes an issue as the produced url is this:

https://store.steampowered.com/search/?term=Command & Conquer Remastered Collection&ignore_preferences=1&category1=998

Which causes the search to be erroneous, in this case turning as `Command` only:

![image](https://github.com/JosefNemec/PlayniteExtensions/assets/1389286/18afed94-992a-41b1-b6c9-10123a5110b4)

This change corrects it to fix searches when the search includes any of the problematic characters:

https://store.steampowered.com/search/?term=Command%20%26%20Conquer%20Remastered%20Collection&ignore_preferences=1&category1=998

![image](https://github.com/JosefNemec/PlayniteExtensions/assets/1389286/cd14a274-eaf8-4981-9ed1-5c4768eed647)