### PR TITLE
Add -nolauncher steam's launch option by default

### DIFF
--- a/source/Libraries/SteamLibrary/SteamGameController.cs
+++ b/source/Libraries/SteamLibrary/SteamGameController.cs
@@ -183,7 +183,7 @@ namespace SteamLibrary
             }
             else
             {
-                ProcessStarter.StartProcess(steamExe, $"-silent \"steam://rungameid/{Game.GameId}\"");
+                ProcessStarter.StartProcess(steamExe, $"-silent \"steam://rungameid/{Game.GameId}//-nolauncher\"");
             }
 
             procMon = new ProcessMonitor();


### PR DESCRIPTION
Add -nolauncher steam's launch option by default so some games like Shadow of Tomb Raider & Galaxy of the Guardians, etc. will launch directly to game instead of game's launcher