### PR TITLE
Add option in Steam's addon settings to use custom Steam's game launch options for Default Play action

### DIFF
--- a/source/Libraries/SteamLibrary/Localization/en_US.xaml
+++ b/source/Libraries/SteamLibrary/Localization/en_US.xaml
@@ -78,5 +78,6 @@
   <sys:String x:Key="LOCSteamValidationFixedTagCount">Fixed tag count must be a valid number</sys:String>
   <sys:String x:Key="LOCSteamShowGameLaunchMenuInDesktopMode">Show Steam's game startup selection menu in desktop mode</sys:String>
   <sys:String x:Key="LOCSteamShowGameLaunchMenuInFullscreenMode">Show Steam's game startup selection menu in fullscreen mode</sys:String>
+  <sys:String x:Key="LOCSteamLaunchOptions">Use Steam's game Launch Options for Default action </sys:String>
   <sys:String x:Key="LOCSteamImportSteamDeckCompatibilityAs">Import Steam Deck compatibility as a</sys:String>
 </ResourceDictionary>

--- a/source/Libraries/SteamLibrary/LocalizationKeys.cs
+++ b/source/Libraries/SteamLibrary/LocalizationKeys.cs
@@ -318,6 +318,10 @@ namespace System
         /// </summary>
         public const string SteamShowGameLaunchMenuInFullscreenMode = "LOCSteamShowGameLaunchMenuInFullscreenMode";
         /// <summary>
+        /// Use Steam's game Launch Options for Default action 
+        /// </summary>
+        public const string SteamLaunchOptions = "LOCSteamLaunchOptions";
+        /// <summary>
         /// Import Steam Deck compatibility as a
         /// </summary>
         public const string SteamImportSteamDeckCompatibilityAs = "LOCSteamImportSteamDeckCompatibilityAs";

--- a/source/Libraries/SteamLibrary/SteamGameController.cs
+++ b/source/Libraries/SteamLibrary/SteamGameController.cs
@@ -183,7 +183,7 @@ namespace SteamLibrary
             }
             else
             {
-                ProcessStarter.StartProcess(steamExe, $"-silent \"steam://rungameid/{Game.GameId}\"");
+                ProcessStarter.StartProcess(steamExe, $"-silent \"steam://rungameid/{Game.GameId}//{(settings.UseSteamLaunchOptions ? settings.SteamLaunchOptions : "")}\"");
             }
 
             procMon = new ProcessMonitor();

--- a/source/Libraries/SteamLibrary/SteamLibrarySettingsView.xaml
+++ b/source/Libraries/SteamLibrary/SteamLibrarySettingsView.xaml
@@ -286,6 +286,10 @@
                           IsChecked="{Binding Settings.ShowSteamLaunchMenuInDesktopMode}"/>
                 <CheckBox Content="{DynamicResource LOCSteamShowGameLaunchMenuInFullscreenMode}"
                           IsChecked="{Binding Settings.ShowSteamLaunchMenuInFullscreenMode}" Margin="0,10,0,10"/>
+				<StackPanel Orientation="Horizontal" Margin="0,12,0,0">
+					<CheckBox Name="UseSteamLaunchOptions" IsChecked="{Binding Settings.UseSteamLaunchOptions}" Content="{DynamicResource LOCSteamLaunchOptions}" VerticalAlignment="Center" Margin="0,0,4,0"/>
+					<TextBox Text="{Binding Settings.SteamLaunchOptions}" VerticalAlignment="Center" Width="200" IsEnabled="{Binding Settings.UseSteamLaunchOptions, ElementName=UseSteamLaunchOptions, Path=IsChecked}"/>
+				</StackPanel>
             </StackPanel>
         </TabItem>        
     </TabControl>

--- a/source/Libraries/SteamLibrary/SteamLibrarySettingsViewModel.cs
+++ b/source/Libraries/SteamLibrary/SteamLibrarySettingsViewModel.cs
@@ -55,6 +55,8 @@ namespace SteamLibrary
         public ObservableCollection<AdditionalSteamAcccount> AdditionalAccounts { get; set; } = new ObservableCollection<AdditionalSteamAcccount>();
         public bool ShowSteamLaunchMenuInDesktopMode { get; set; } = true;
         public bool ShowSteamLaunchMenuInFullscreenMode { get; set; } = false;
+        public bool UseSteamLaunchOptions { get; set; } = false;
+        public string SteamLaunchOptions { get; set; } = string.Empty;
         [Obsolete] public string ApiKey { get; set; }
         [DontSerialize] public string RutnimeApiKey { get => apiKey; set => SetValue(ref apiKey, value); }
     }

--- a/source/Localization/en_US.xaml
+++ b/source/Localization/en_US.xaml
@@ -104,6 +104,7 @@ If disabled, the game page will be opened to manually start the install process.
     <sys:String x:Key="LOCSteamValidationFixedTagCount">Fixed tag count must be a valid number</sys:String>
     <sys:String x:Key="LOCSteamShowGameLaunchMenuInDesktopMode">Show Steam's game startup selection menu in desktop mode</sys:String>
     <sys:String x:Key="LOCSteamShowGameLaunchMenuInFullscreenMode">Show Steam's game startup selection menu in fullscreen mode</sys:String>
+	<sys:String x:Key="LOCSteamLaunchOptions">Use Steam's game Launch Options for Default action </sys:String>
     <sys:String x:Key="LOCSteamImportSteamDeckCompatibilityAs">Import Steam Deck compatibility as a</sys:String>
     <!--IGDB-->
     <sys:String x:Key="LOCIgdbUseScreenshotIfNecessary">Use screenshots if artwork is not available</sys:String>

--- a/source/Metadata/UniversalSteamMetadata/Localization/en_US.xaml
+++ b/source/Metadata/UniversalSteamMetadata/Localization/en_US.xaml
@@ -78,5 +78,6 @@
   <sys:String x:Key="LOCSteamValidationFixedTagCount">Fixed tag count must be a valid number</sys:String>
   <sys:String x:Key="LOCSteamShowGameLaunchMenuInDesktopMode">Show Steam's game startup selection menu in desktop mode</sys:String>
   <sys:String x:Key="LOCSteamShowGameLaunchMenuInFullscreenMode">Show Steam's game startup selection menu in fullscreen mode</sys:String>
+  <sys:String x:Key="LOCSteamLaunchOptions">Use Steam's game Launch Options for Default action </sys:String>
   <sys:String x:Key="LOCSteamImportSteamDeckCompatibilityAs">Import Steam Deck compatibility as a</sys:String>
 </ResourceDictionary>

--- a/source/Metadata/UniversalSteamMetadata/LocalizationKeys.cs
+++ b/source/Metadata/UniversalSteamMetadata/LocalizationKeys.cs
@@ -318,6 +318,10 @@ namespace System
         /// </summary>
         public const string SteamShowGameLaunchMenuInFullscreenMode = "LOCSteamShowGameLaunchMenuInFullscreenMode";
         /// <summary>
+        /// Use Steam's game Launch Options for Default action 
+        /// </summary>
+        public const string SteamLaunchOptions = "LOCSteamLaunchOptions";
+        /// <summary>
         /// Import Steam Deck compatibility as a
         /// </summary>
         public const string SteamImportSteamDeckCompatibilityAs = "LOCSteamImportSteamDeckCompatibilityAs";


### PR DESCRIPTION
As last denied commit due to the hard coded -nolauncher is really a bad practice. Thus I make this change to have an option to set custom launch action for Default Play action (disabled by default). 

P/s: A new Localization value I only added in English file