### PR TITLE
UniversalSteamMetadata: Fix description text having whitespace

### DIFF
--- a/source/Metadata/UniversalSteamMetadata/UniversalSteamMetadata.cs
+++ b/source/Metadata/UniversalSteamMetadata/UniversalSteamMetadata.cs
@@ -68,7 +68,7 @@ namespace UniversalSteamMetadata
                 foreach (var gameElem in searchPage.QuerySelectorAll(".search_result_row"))
                 {
                     var title = gameElem.QuerySelector(".title").InnerHtml;
-                    var releaseDate = gameElem.QuerySelector(".search_released").InnerHtml;
+                    var releaseDate = gameElem.QuerySelector(".search_released").InnerHtml.Trim();
                     if (gameElem.HasAttribute("data-ds-packageid"))
                     {
                         continue;


### PR DESCRIPTION
Steam has been changing the results page and now the release date html element has whitespace on the sides.

Before:

![Playnite DesktopApp_fVKDwYskDI](https://github.com/JosefNemec/PlayniteExtensions/assets/1389286/367c87bb-2a57-4184-8b51-1764c265dc54)

After:


![7GSCEoFCM1](https://github.com/JosefNemec/PlayniteExtensions/assets/1389286/e66e3dc6-b563-498c-be06-1a4ff40203d2)
