### PR TITLE
Implement new Xbox Live authentication method

### DIFF
--- a/source/Libraries/XboxLibrary/Models/AuthenticationData.cs
+++ b/source/Libraries/XboxLibrary/Models/AuthenticationData.cs
@@ -10,7 +10,7 @@ namespace XboxLibrary.Models
     {
         public string AccessToken;
         public string RefreshToken;
-        public string ExpiresIn;
+        public int ExpiresIn;
         public DateTime CreationDate;
         public string UserId;
         public string TokenType;
@@ -145,6 +145,7 @@ namespace XboxLibrary.Models
     public class RefreshTokenResponse
     {
         public string token_type;
+        public int expires_in;
         public string scope;
         public string access_token;
         public string refresh_token;


### PR DESCRIPTION
Based on https://github.com/OpenXbox/xbox-webapi-python as suggested in #338.

The `client_id` and `client_secret` constants need to be updated with values from your Playnite app registration in Azure. I tested the code with values from an app registration I created in my Azure account. I followed [the instructions from the Python project](https://github.com/OpenXbox/xbox-webapi-python#xbox-webapi), except for the Redirect URI I used `https://login.live.com/oauth20_desktop.srf` as can be seen from code, because I couldn't manage to read the authorization code from the web view if I used localhost as suggested there.