### PR TITLE
[#3203] Add install support for Itchio

### DIFF
--- a/source/Libraries/ItchioLibrary/ItchioGameController.cs
+++ b/source/Libraries/ItchioLibrary/ItchioGameController.cs
@@ -39,7 +39,7 @@ namespace ItchioLibrary
             }
 
             Dispose();
-            ProcessStarter.StartUrl("itch://library/owned");
+            ProcessStarter.StartUrl("itch://install?game_id=" + Game.GameId)
             StartInstallWatcher();
         }
 

--- a/source/Libraries/ItchioLibrary/ItchioGameController.cs
+++ b/source/Libraries/ItchioLibrary/ItchioGameController.cs
@@ -39,7 +39,7 @@ namespace ItchioLibrary
             }
 
             Dispose();
-            ProcessStarter.StartUrl("itch://install?game_id=" + Game.GameId)
+            ProcessStarter.StartUrl("itch://install?game_id=" + Game.GameId);
             StartInstallWatcher();
         }
 


### PR DESCRIPTION
There exists an Itch.io url to pass as a command line argument for installing. URLs of the form 'itch://install?game_id=###' will prompt the itch client to open the installation dialog box.

I believe this addresses the issue here: https://github.com/JosefNemec/Playnite/issues/3203

I've built the extension locally and loaded into Playnite. Installing Itch games has the desired behavior. 

The itch.io source I referenced for the install feature is here: https://github.com/itchio/itch/blob/102011c51dc26a3142795c67394c365bb09cb309/src/main/reactors/url.ts#L96

I confirmed that the Game ID argument inside of Playnite matches what the Itch Client is expecting. I chose an Itch game and used Playnite to lookup the Game Id. I then ran the url using the Windows Run command and had Itch.Io work as expected.
I haven't explored further but the build_id is optional, and probably preselects the itch dropdown when a game has multiple downloads. 

![image](https://github.com/JosefNemec/PlayniteExtensions/assets/4739658/8f9c3a3a-7883-4169-b736-31c5a191cd80)

![image](https://github.com/JosefNemec/PlayniteExtensions/assets/4739658/6f3f957d-0097-4f02-9584-6249c4ec4d62)

![image](https://github.com/JosefNemec/PlayniteExtensions/assets/4739658/5bcb920e-fcb3-48cd-b7ca-6d9d54a48f1b)

