### PR TITLE
Epic Games: Skip importing Ubisoft games

### DIFF
--- a/source/Libraries/EpicLibrary/EpicLibrary.cs
+++ b/source/Libraries/EpicLibrary/EpicLibrary.cs
@@ -128,6 +128,11 @@ namespace EpicLibrary
                 {
                     continue;
                 }
+                
+                if ((catalogItem?.customAttributes?.ContainsKey("partnerLinkType") == true) && (catalogItem.customAttributes["partnerLinkType"].value == "ubisoft"))
+                {
+                    continue;
+                }
 
                 var newGame = new GameMetadata
                 {


### PR DESCRIPTION
They require Ubisoft Connect to launch, so skip importing them to prevent duplicates ♻️.