### PR TITLE
itch: on install automatically open install dialog in itch client

### DIFF
--- a/source/Libraries/ItchioLibrary/ItchioGameController.cs
+++ b/source/Libraries/ItchioLibrary/ItchioGameController.cs
@@ -39,7 +39,7 @@ namespace ItchioLibrary
             }
 
             Dispose();
-            ProcessStarter.StartUrl("itch://library/owned");
+            ProcessStarter.StartUrl($"itch://install?game_id={Game.GameId}");
             StartInstallWatcher();
         }
 


### PR DESCRIPTION
Use the `itch://install?game_id=1234` URI format to automatically launch the game install dialog inside the Itch client. If the `game_id` is invalid, the dialog will not open but the client is still launched, which is about the same as the previous behavior. The install dialog is also correctly launched even if the user needs to click through the Itch login process.