### PR TITLE
Epic: Skip importing non-launchable DLCs

### DIFF
--- a/source/Libraries/EpicLibrary/EpicLibrary.cs
+++ b/source/Libraries/EpicLibrary/EpicLibrary.cs
@@ -124,7 +124,7 @@ namespace EpicLibrary
                     continue;
                 }
 
-                if (catalogItem?.categories?.Any(a => a.path == "dlc") == true)
+                if ((catalogItem?.categories?.Any(a => a.path == "addons") == true) && (catalogItem.categories.Any(a => a.path == "addons/launchable") == false))
                 {
                     continue;
                 }


### PR DESCRIPTION
Looks like there is already condition to skip importing DLCs, but it's not working.
From some time also weird launchable DLCs exists (like Rocket Racing), so I excluded them, but installing them doesn't work currently unfortunately, Epic says that base game is required.