### PR TITLE
Fixed Xbox app process URL

### DIFF
--- a/source/Libraries/XboxLibrary/XboxLibraryClient.cs
+++ b/source/Libraries/XboxLibrary/XboxLibraryClient.cs
@@ -34,7 +34,7 @@ namespace XboxLibrary
             }
             else
             {
-                ProcessStarter.StartUrl("ms-windows-store://");
+                ProcessStarter.StartUrl("xbox://");
             }
         }
     }


### PR DESCRIPTION
The app currently opens the MS Store app when you right-click -> 3rd Party Clients -> Xbox
Whe commit changes the URL to open the actual Xbox app.
![image](https://github.com/JosefNemec/PlayniteExtensions/assets/16973183/861261a1-2228-42d8-93bb-af429a413024)
