### PR TITLE
UniversalSteamMetadata: Fix missing games in search

### DIFF
--- a/source/Metadata/UniversalSteamMetadata/UniversalSteamMetadata.cs
+++ b/source/Metadata/UniversalSteamMetadata/UniversalSteamMetadata.cs
@@ -14,7 +14,7 @@ namespace UniversalSteamMetadata
     [LoadPlugin]
     public class UniversalSteamMetadata : MetadataPluginBase<UniversalSteamMetadataSettingsViewModel>
     {
-        private const string searchUrl = @"https://store.steampowered.com/search/?term={0}&ignore_preferences=1&category1=998";
+        private const string searchUrl = @"https://store.steampowered.com/search/?term={0}&ignore_preferences=1&category1=998&ndl=1";
         private readonly string[] backgroundUrls = new string[]
         {
             @"https://steamcdn-a.akamaihd.net/steam/apps/{0}/page.bg.jpg",


### PR DESCRIPTION
Currently games don't show in search results if game doesn't have English or any of the user languages. This parameter removes languages narrowing to show all games:

https://store.steampowered.com/search/?term=nayuta+no+kiseki&ignore_preferences=1&category1=998&ndl=1

Before:
![Playnite DesktopApp_hgSYyhWAhx](https://github.com/JosefNemec/PlayniteExtensions/assets/1389286/c50b5502-2066-4b16-8d87-d9d06761b375)

After:
![Playnite DesktopApp_Ew98K6V2CC](https://github.com/JosefNemec/PlayniteExtensions/assets/1389286/f5740310-42b7-4dfb-ad3e-6f0a21f5b76d)