### PR TITLE
Epic: Skip importing unnecessary DLCs

### DIFF
--- a/source/Libraries/EpicLibrary/EpicLibrary.cs
+++ b/source/Libraries/EpicLibrary/EpicLibrary.cs
@@ -124,11 +124,16 @@ namespace EpicLibrary
                     continue;
                 }
 
-                if ((catalogItem?.categories?.Any(a => a.path == "addons") == true) && (catalogItem.categories.Any(a => a.path == "addons/launchable") == false))
+                if ((catalogItem?.mainGameItem != null) && (catalogItem.categories?.Any(a => a.path == "addons/launchable") == false))
                 {
                     continue;
                 }
-                
+
+                if (catalogItem?.categories?.Any(a => a.path == "digitalextras") == true)
+                {
+                    continue;
+                }
+
                 if ((catalogItem?.customAttributes?.ContainsKey("partnerLinkType") == true) && (catalogItem.customAttributes["partnerLinkType"].value == "ubisoft"))
                 {
                     continue;

--- a/source/Libraries/EpicLibrary/Models/CatalogResponse.cs
+++ b/source/Libraries/EpicLibrary/Models/CatalogResponse.cs
@@ -32,6 +32,11 @@ namespace EpicLibrary.Models
             public DateTime? dateAdded;
         }
 
+        public class MainGameItem
+        {
+            public string id;
+        }
+
         public string id;
         public string title;
         public string description;
@@ -49,6 +54,7 @@ namespace EpicLibrary.Models
         public string developer;
         public string developerId;
         public bool endOfSupport;
+        public MainGameItem mainGameItem;
     }
 
 

--- a/source/Libraries/EpicLibrary/Services/EpicAccountClient.cs
+++ b/source/Libraries/EpicLibrary/Services/EpicAccountClient.cs
@@ -226,7 +226,7 @@ namespace EpicLibrary.Services
 
             if (result == null)
             {
-                var url = string.Format("{0}/bulk/items?id={1}&country=US&locale=en-US", nameSpace, id);
+                var url = string.Format("{0}/bulk/items?id={1}&country=US&locale=en-US&includeMainGameDetails=true", nameSpace, id);
                 var catalogResponse = InvokeRequest<Dictionary<string, CatalogItem>>(catalogUrl + url, loadTokens()).GetAwaiter().GetResult();
                 result = catalogResponse.Item2;
                 FileSystem.WriteStringToFile(cachePath, catalogResponse.Item1);


### PR DESCRIPTION
I noticed that still some non-launchable DLCs (ex. Dying Light The Following), soundtracks and artbooks are imported.
Apparently not all of them have "addons" category, but I found better way.