### PR TITLE
Amazon: Fix failing to obtain game library (#401)

### DIFF
--- a/source/Libraries/AmazonGamesLibrary/Models/EntitlementsRequest.cs
+++ b/source/Libraries/AmazonGamesLibrary/Models/EntitlementsRequest.cs
@@ -15,5 +15,7 @@ namespace AmazonGamesLibrary.Models
         public int maxResults = 500;
         public string keyId;
         public string hardwareHash;
+        public string productIdFilter = null;
+        public bool disableStateFilter = true;
     }
 }

--- a/source/Libraries/AmazonGamesLibrary/Models/EntitlementsRequest.cs
+++ b/source/Libraries/AmazonGamesLibrary/Models/EntitlementsRequest.cs
@@ -8,7 +8,7 @@ namespace AmazonGamesLibrary.Models
 {
     public class EntitlementsRequest
     {
-        public string Operation = "GetEntitlementsV2";
+        public string Operation = "GetEntitlements";
         public string clientId = "Sonic";
         public int syncPoint = 0;
         public string nextToken;

--- a/source/Libraries/AmazonGamesLibrary/Services/AmazonAccountClient.cs
+++ b/source/Libraries/AmazonGamesLibrary/Services/AmazonAccountClient.cs
@@ -110,8 +110,8 @@ namespace AmazonGamesLibrary.Services
             var token = LoadToken();
             using (var client = new HttpClient())
             {
-                client.DefaultRequestHeaders.Add("User-Agent", "com.amazon.agslauncher.win/2.1.5699.1");
-                client.DefaultRequestHeaders.Add("X-Amz-Target", "com.amazonaws.gearbox.softwaredistribution.service.model.SoftwareDistributionService.GetEntitlementsV2");
+                client.DefaultRequestHeaders.Add("User-Agent", "com.amazon.agslauncher.win/3.0.9124.0");
+                client.DefaultRequestHeaders.Add("X-Amz-Target", "com.amazon.animusdistributionservice.entitlement.AnimusEntitlementsService.GetEntitlements");
                 client.DefaultRequestHeaders.Add("x-amzn-token", token.access_token);
 
                 string nextToken = null;
@@ -130,7 +130,7 @@ namespace AmazonGamesLibrary.Services
                     strCont.Headers.TryAddWithoutValidation("Content-Encoding", "amz-1.0");
 
                     var entlsResponse = await client.PostAsync(
-                        @"https://sds.amazon.com/amazon/",
+                        @"https://gaming.amazon.com/api/distribution/entitlements",
                         strCont);
 
                     var entlsResponseContent = await entlsResponse.Content.ReadAsStringAsync();


### PR DESCRIPTION
- Fixes failing to obtain games during library update. (#401)
- While not needed, I added two missing parameters in the request body and updated the user agent for good measure.