### PR TITLE
Epic: Skip importing games requiring EA App

### DIFF
--- a/source/Libraries/EpicLibrary/EpicLibrary.cs
+++ b/source/Libraries/EpicLibrary/EpicLibrary.cs
@@ -134,6 +134,11 @@ namespace EpicLibrary
                     continue;
                 }
 
+                if ((catalogItem?.customAttributes?.ContainsKey("ThirdPartyManagedApp") == true) && (catalogItem?.customAttributes["ThirdPartyManagedApp"].value.ToLower() == "the ea app"))
+                {
+                    continue;
+                }
+
                 if ((catalogItem?.customAttributes?.ContainsKey("partnerLinkType") == true) && (catalogItem.customAttributes["partnerLinkType"].value == "ubisoft"))
                 {
                     continue;


### PR DESCRIPTION
Looks like Epic changed something and now games requiring EA App are importing (for example Dragon Age Inquisition). However old Origin games are still skipped.