### PR TITLE
Epic: Adding optional ubisoft import toggle

### DIFF
--- a/source/Libraries/EpicLibrary/EpicLibrary.cs
+++ b/source/Libraries/EpicLibrary/EpicLibrary.cs
@@ -134,7 +134,7 @@ namespace EpicLibrary
                     continue;
                 }
 
-                if ((catalogItem?.customAttributes?.ContainsKey("partnerLinkType") == true) && (catalogItem.customAttributes["partnerLinkType"].value == "ubisoft"))
+                if (!SettingsViewModel.Settings.ImportUbisoftGames && (catalogItem?.customAttributes?.ContainsKey("partnerLinkType") == true) && (catalogItem.customAttributes["partnerLinkType"].value == "ubisoft"))
                 {
                     continue;
                 }

--- a/source/Libraries/EpicLibrary/EpicLibrarySettingsView.xaml
+++ b/source/Libraries/EpicLibrary/EpicLibrarySettingsView.xaml
@@ -34,6 +34,11 @@
                       Margin="0,10,0,0"
                       Content="{DynamicResource LOCEpicSettingsImportUninstalledLabel}"/>
 
+            <CheckBox DockPanel.Dock="Top" Name="CheckEpicImportUbisoft"
+                      IsChecked="{Binding Settings.ImportUbisoftGames}"
+                      Margin="0,10,0,0"
+                      Content="{DynamicResource LOCEpicImportUbisoft}"/>
+
             <StackPanel Orientation="Horizontal"
                         DockPanel.Dock="Top" Margin="0,15,5,5" HorizontalAlignment="Left">
                 <Button Content="{DynamicResource LOCEpicAuthenticateLabel}" HorizontalAlignment="Left"

--- a/source/Libraries/EpicLibrary/EpicLibrarySettingsViewModel.cs
+++ b/source/Libraries/EpicLibrary/EpicLibrarySettingsViewModel.cs
@@ -22,6 +22,7 @@ namespace EpicLibrary
         public bool ImportInstalledGames { get; set; } = EpicLauncher.IsInstalled;
         public bool ConnectAccount { get; set; } = false;
         public bool ImportUninstalledGames { get; set; } = false;
+        public bool ImportUbisoftGames { get; set; } = false;
     }
 
     public class EpicLibrarySettingsViewModel : PluginSettingsViewModel<EpicLibrarySettings, EpicLibrary>
@@ -53,6 +54,11 @@ namespace EpicLibrary
                     if (savedSettings.ImportUninstalledGames)
                     {
                         savedSettings.ConnectAccount = true;
+                    }
+
+                    if (savedSettings.ImportUbisoftGames)
+                    {
+                        savedSettings.ImportUbisoftGames = true;
                     }
                 }
 

--- a/source/Libraries/EpicLibrary/Localization/en_US.xaml
+++ b/source/Libraries/EpicLibrary/Localization/en_US.xaml
@@ -1,6 +1,7 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib">
   <sys:String x:Key="LOCEpicSettingsImportInstalledLabel">Import installed games</sys:String>
   <sys:String x:Key="LOCEpicSettingsImportUninstalledLabel">Import not installed games</sys:String>
+  <sys:String x:Key="LOCEpicImportUbisoft">Import Ubisoft Games</sys:String>
   <sys:String x:Key="LOCEpicSettingsConnectAccount">Connect account</sys:String>
   <sys:String x:Key="LOCEpicLoginChecking">Checking authentication status…</sys:String>
   <sys:String x:Key="LOCEpicLoggedIn">User is authenticated</sys:String>


### PR DESCRIPTION
Adds a check box in the library options defaulted to false. If selected it'll operate as it used to before the change to ignore them was implemented.