### PR TITLE
Xbox: Support to open game page on Xbox App when Installing

### DIFF
--- a/source/Libraries/XboxLibrary/Models/AuthenticationData.cs
+++ b/source/Libraries/XboxLibrary/Models/AuthenticationData.cs
@@ -75,11 +75,18 @@ namespace XboxLibrary.Models
             public string developerName;
             public DateTime? releaseDate;
             public int? minAge;
+            public List<Availability> availabilities;
         }
 
         public class TitleHistory
         {
             public DateTime? lastTimePlayed;
+        }
+
+        public class Availability
+        {
+            public List<string> Platforms;
+            public string ProductId;
         }
 
         public class Title

--- a/source/Libraries/XboxLibrary/Xbox.cs
+++ b/source/Libraries/XboxLibrary/Xbox.cs
@@ -1,6 +1,7 @@
 ﻿using Playnite.Common;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -14,6 +15,7 @@ namespace XboxLibrary
         private const string xboxPassAppFN = "Microsoft.GamingApp_8wekyb3d8bbwe";
 
         private static bool? isXboxPassAppInstalled;
+        public static bool IsRunning => Process.GetProcessesByName("XboxPcApp").Length > 0;
         public static bool IsXboxPassAppInstalled
         {
             get
@@ -56,6 +58,11 @@ namespace XboxLibrary
             {
                 throw new NotSupportedException("Only supported on Windows 10 and newer.");
             }
+        }
+
+        public static void OpenGamePage(string productId)
+        {
+            ProcessStarter.StartUrl($"msxbox://game/?productId={productId}");
         }
 
         public static string Icon { get; } = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), @"icon.png");

--- a/source/Libraries/XboxLibrary/XboxGameController.cs
+++ b/source/Libraries/XboxLibrary/XboxGameController.cs
@@ -18,16 +18,23 @@ namespace XboxLibrary
     {
         private readonly bool userXboxApp;
         private CancellationTokenSource watcherToken;
+        private readonly string productId;
+        private readonly string logsDirectoryWatcherPath;
+        private FileSystemWatcher fileSystemWatcher;
 
-        public XboxInstallController(Game game, bool useXboxApp) : base(game)
+        public XboxInstallController(Game game, bool useXboxApp, string productId) : base(game)
         {
             this.userXboxApp = useXboxApp;
-            Name = useXboxApp ? "Install using Xbox app" : "Install using MS Store";
-        }
+            this.productId = productId;
+            logsDirectoryWatcherPath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "Packages",
+                "Microsoft.GamingApp_8wekyb3d8bbwe",
+                "AC",
+                "Temp"
+            );
 
-        public override void Dispose()
-        {
-            watcherToken?.Cancel();
+            Name = useXboxApp ? "Install using Xbox app" : "Install using MS Store";
         }
 
         public override void Install(InstallActionArgs args)
@@ -35,11 +42,27 @@ namespace XboxLibrary
             Dispose();
             if (userXboxApp)
             {
-                Xbox.OpenXboxPassApp();
-            }
-            else
-            {
-                ProcessStarter.StartUrl($"ms-windows-store://pdp/?PFN={Game.GameId}");
+                if (productId.IsNullOrEmpty())
+                {
+                    Xbox.OpenXboxPassApp();
+                }
+                else if (Xbox.IsRunning)
+                {
+                    // If the Xbox app is already running, it's possible to open the game page without issues.
+                    Xbox.OpenGamePage(productId);
+                }
+                else
+                {
+                    // Note: A recent update to the Xbox app introduced a bug where the URI to open the product page fails 
+                    // until the app has fully initialized. This issue did not occur in earlier versions of the app.
+                    //
+                    // To determine when the app has fully initialized, we monitor for changes in a specific log file, 
+                    // which is created or modified only after the initialization is complete.
+                    // Alternative approaches, such as monitoring running processes, tracking changes in application windows, 
+                    // or detecting locked files, were ineffective for addressing this scenario.
+                    Xbox.OpenXboxPassApp();
+                    InitializeFileSystemWatcher();
+                }
             }
 
             StartInstallWatcher();
@@ -54,12 +77,14 @@ namespace XboxLibrary
                 {
                     if (watcherToken.IsCancellationRequested)
                     {
+                        DisableFileSystemWatcher();
                         return;
                     }
 
                     var app = Programs.GetUWPApps().FirstOrDefault(a => a.AppId == Game.GameId);
                     if (app != null)
                     {
+                        DisableFileSystemWatcher();
                         var installInfo = new GameInstallationData
                         {
                             InstallDirectory = app.WorkDir
@@ -72,6 +97,53 @@ namespace XboxLibrary
                     await Task.Delay(10000);
                 }
             });
+        }
+
+        private void DisableFileSystemWatcher()
+        {
+            if (fileSystemWatcher != null)
+            {
+                fileSystemWatcher.EnableRaisingEvents = false;
+            }
+        }
+
+        private void InitializeFileSystemWatcher()
+        {
+            if (!FileSystem.DirectoryExists(logsDirectoryWatcherPath))
+            {
+                return;
+            }
+            
+            fileSystemWatcher = new FileSystemWatcher(logsDirectoryWatcherPath)
+            {
+                NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName,
+                Filter = "*.*",
+                EnableRaisingEvents = true
+            };
+
+            fileSystemWatcher.Changed += OnFileChanged;
+            fileSystemWatcher.Created += OnFileChanged;
+            fileSystemWatcher.Renamed += OnFileChanged;
+        }
+
+        private void OnFileChanged(object sender, FileSystemEventArgs e)
+        {
+            DisableFileSystemWatcher();
+            Xbox.OpenGamePage(productId);
+        }
+
+        public override void Dispose()
+        {
+            watcherToken?.Cancel();
+            if (fileSystemWatcher != null)
+            {
+                fileSystemWatcher.EnableRaisingEvents = false;
+                fileSystemWatcher.Changed -= OnFileChanged;
+                fileSystemWatcher.Created -= OnFileChanged;
+                fileSystemWatcher.Renamed -= OnFileChanged;
+                fileSystemWatcher.Dispose();
+                fileSystemWatcher = null;
+            }
         }
     }
 


### PR DESCRIPTION
Replaces the #169 PR.

Note:
Only thing of note is that it was quite tricky to make use of the URI this time. It looks like a recent update (Or at least since the last time I attempted to use the URI a few years ago) to the Xbox app introduced a bug where the URI to open the product page fails until the app has fully initialized. This issue did not occur in earlier versions of the app.

To determine when the app has fully initialized and after hours of trying different approaches, the only solution I found was to monitor a specific directory where I found that files are modified the moment the app is ready. It's not the ideal solution but it worked reliably and perfectly in all my tests. Perhaps we should be on the lookout in the future to see if this issue is fixed in an update to remove this workaround.