### PR TITLE
Steam: Library update and metadata download game name fixes

### DIFF
--- a/source/Libraries/SteamLibrary/SteamLibrary.cs
+++ b/source/Libraries/SteamLibrary/SteamLibrary.cs
@@ -151,7 +151,7 @@ namespace SteamLibrary
             {
                 Source = new MetadataNameProperty("Steam"),
                 GameId = gameId.ToString(),
-                Name = name.RemoveTrademarks(),
+                Name = name.RemoveTrademarks().Trim(),
                 InstallDirectory = installDir,
                 IsInstalled = true,
                 Platforms = new HashSet<MetadataProperty> { new MetadataSpecProperty("pc_windows") }
@@ -258,7 +258,7 @@ namespace SteamLibrary
             {
                 Source = new MetadataNameProperty("Steam"),
                 GameId = modInfo.GameId.ToString(),
-                Name = modInfo.Name.RemoveTrademarks(),
+                Name = modInfo.Name.RemoveTrademarks().Trim(),
                 InstallDirectory = path,
                 IsInstalled = true,
                 Developers = new HashSet<MetadataProperty>() { new MetadataNameProperty(modInfo.Developer) },
@@ -503,7 +503,7 @@ namespace SteamLibrary
                 var newGame = new GameMetadata()
                 {
                     Source = new MetadataNameProperty("Steam"),
-                    Name = game.name.RemoveTrademarks(),
+                    Name = game.name.RemoveTrademarks().Trim(),
                     GameId = game.appid.ToString(),
                     Platforms = new HashSet<MetadataProperty> { new MetadataSpecProperty("pc_windows") }
                 };

--- a/source/Libraries/SteamLibrary/SteamShared/MetadataProvider.cs
+++ b/source/Libraries/SteamLibrary/SteamShared/MetadataProvider.cs
@@ -270,6 +270,7 @@ namespace Steam
                 metadata.Name = metadata.ProductDetails?["common"]["name"]?.Value ?? metadata.StoreDetails?.name;
             }
 
+            metadata.Name = metadata.Name.Trim();
             metadata.Links = new List<Link>()
             {
                 new Link(ResourceProvider.GetString(LOC.SteamLinksCommunityHub), $"https://steamcommunity.com/app/{appId}"),

--- a/source/Libraries/SteamLibrary/SteamShared/MetadataProvider.cs
+++ b/source/Libraries/SteamLibrary/SteamShared/MetadataProvider.cs
@@ -270,7 +270,7 @@ namespace Steam
                 metadata.Name = metadata.ProductDetails?["common"]["name"]?.Value ?? metadata.StoreDetails?.name;
             }
 
-            metadata.Name = metadata.Name.Trim();
+            metadata.Name = metadata.Name.RemoveTrademarks().Trim();
             metadata.Links = new List<Link>()
             {
                 new Link(ResourceProvider.GetString(LOC.SteamLinksCommunityHub), $"https://steamcommunity.com/app/{appId}"),


### PR DESCRIPTION
This affects both the Steam library and Steam metadata plugin.

### Fixes:

**1. Remove trailing whitespace in game names:** Not a major issue but sometimes games contain unintended trailing whitespace. This has gone undetected for many years and is more common than I'd have thought, in my library I found around 40~50 games with this issue. It looks to be an issue in the returned data from Steam, but can also happen if there's a Trademark character, which is currently removed, that is leaded by whitespace. While not a critical issue, this has the potential to affect other parts of the application or plugins in situations where the game name is used for different scenarios, including matching using the name.

**2. Remove trademark characters when downloading metadata:** Currently these characters are only removed when games are imported on library update but not during metadata download. This affects, for example, the Batman Arkham games.

### Screenshots to showcase the issue:

**Library update:**

![image](https://github.com/user-attachments/assets/ba1a29b5-25ed-4d00-b0d4-40ed56bcb2d5)

**Metadata update:**

Inconsistency: Product details incorrectly includes trailing whitespace, store details doesn't.

![image](https://github.com/user-attachments/assets/3e72e360-1379-442a-bd0a-11eff727edfa)

![image](https://github.com/user-attachments/assets/fc105c88-d502-4b57-884c-22d64c881394)

![Playnite DesktopApp_eYmY6QhL4t](https://github.com/user-attachments/assets/42b35733-93b7-4708-aac1-ff52254f36c7)
