### PR TITLE
Steam: Fix freezes during Uninstall

### DIFF
--- a/source/Libraries/SteamLibrary/SteamGameController.cs
+++ b/source/Libraries/SteamLibrary/SteamGameController.cs
@@ -113,22 +113,25 @@ namespace SteamLibrary
             watcherToken = new CancellationTokenSource();
             var id = Game.ToSteamGameID();
 
-            while (true)
+            await Task.Run(async () =>
             {
-                if (watcherToken.IsCancellationRequested)
+                while (true)
                 {
-                    return;
-                }
+                    if (watcherToken.IsCancellationRequested)
+                    {
+                        return;
+                    }
 
-                var installed = SteamLibrary.GetInstalledGames(false);
-                if (!installed.ContainsKey(id))
-                {
-                    InvokeOnUninstalled(new GameUninstalledEventArgs());
-                    return;
-                }
+                    var installed = SteamLibrary.GetInstalledGames(false);
+                    if (!installed.ContainsKey(id))
+                    {
+                        InvokeOnUninstalled(new GameUninstalledEventArgs());
+                        return;
+                    }
 
-                await Task.Delay(5_000);
-            }
+                    await Task.Delay(5_000);
+                }
+            });
         }
     }
 


### PR DESCRIPTION
Fixes:
- Freezing Playnite UI during uninstall process while obtaining installed games: https://github.com/JosefNemec/PlayniteExtensions/blob/7c471edfeea4ed1384f97c14ad76c48988453248/source/Libraries/SteamLibrary/SteamGameController.cs#L123

Issue doesn't occur in Install controller because the Watcher is already running in a Task.

Before:

https://github.com/user-attachments/assets/f4cb244b-1a67-4c78-bd6e-1121322f8486

After:

https://github.com/user-attachments/assets/32bce657-2e0c-4132-ac9b-ff35adefcc82

