### PR TITLE
Steam: Improve installed games scan time by scanning in parallel

### DIFF
--- a/source/Libraries/SteamLibrary/SteamLibrary.cs
+++ b/source/Libraries/SteamLibrary/SteamLibrary.cs
@@ -7,12 +7,14 @@ using SteamKit2;
 using SteamLibrary.Models;
 using SteamLibrary.Services;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
 using System.Text;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
@@ -50,6 +52,7 @@ namespace SteamLibrary
     public class SteamLibrary : LibraryPluginBase<SteamLibrarySettingsViewModel>
     {
         private static readonly ILogger logger = LogManager.GetLogger();
+        private const int libScanParallelismDegree = 3;
         private readonly Configuration config;
         internal SteamServicesClient ServicesClient;
         internal TopPanelItem TopPanelFriendsButton;
@@ -162,13 +165,13 @@ namespace SteamLibrary
 
         internal static List<GameMetadata> GetInstalledGamesFromFolder(string path)
         {
-            var games = new List<GameMetadata>();
-
-            foreach (var file in Directory.GetFiles(path, @"appmanifest*"))
+            var games = new ConcurrentBag<GameMetadata>();
+            var appManifests = Directory.GetFiles(path, @"appmanifest*");
+            Parallel.ForEach(appManifests, new ParallelOptions { MaxDegreeOfParallelism = libScanParallelismDegree }, file =>
             {
                 if (file.EndsWith("tmp", StringComparison.OrdinalIgnoreCase))
                 {
-                    continue;
+                    return;
                 }
 
                 try
@@ -176,13 +179,13 @@ namespace SteamLibrary
                     var game = GetInstalledGameFromFile(Path.Combine(path, file));
                     if (game == null)
                     {
-                        continue;
+                        return;
                     }
 
                     if (game.InstallDirectory.IsNullOrEmpty() || game.InstallDirectory.Contains(@"steamapps\music"))
                     {
                         logger.Info($"Steam game {game.Name} is not properly installed or it's a soundtrack, skipping.");
-                        continue;
+                        return;
                     }
 
                     games.Add(game);
@@ -192,17 +195,22 @@ namespace SteamLibrary
                     // Steam can generate invalid acf file according to issue #37
                     logger.Error(exc, $"Failed to get information about installed game from: {file}");
                 }
-            }
+            });
 
-            return games;
+            return games.ToList();
         }
 
         internal static List<GameMetadata> GetInstalledGoldSrcModsFromFolder(string path)
         {
-            var games = new List<GameMetadata>();
+            var games = new ConcurrentBag<GameMetadata>();
             var dirInfo = new DirectoryInfo(path);
 
-            foreach (var folder in dirInfo.GetDirectories().Where(a => !firstPartyModPrefixes.Any(prefix => a.Name.StartsWith(prefix))).Select(a => a.FullName))
+            var filteredDirectories = dirInfo.GetDirectories()
+                .Where(a => !firstPartyModPrefixes.Any(prefix => a.Name.StartsWith(prefix)))
+                .Select(a => a.FullName)
+                .ToList();
+
+            Parallel.ForEach(filteredDirectories, new ParallelOptions { MaxDegreeOfParallelism = libScanParallelismDegree }, folder =>
             {
                 try
                 {
@@ -215,18 +223,18 @@ namespace SteamLibrary
                 catch (Exception exc)
                 {
                     // GameMetadata.txt may not exist or may be invalid
-                    logger.Error(exc, $"Failed to get information about installed GoldSrc mod from: {path}");
+                    logger.Error(exc, $"Failed to get information about installed GoldSrc mod from Path: {path}, Folder: {folder}");
                 }
-            }
+            });
 
-            return games;
+            return games.ToList();
         }
 
         internal static List<GameMetadata> GetInstalledSourceModsFromFolder(string path)
         {
-            var games = new List<GameMetadata>();
-
-            foreach (var folder in Directory.GetDirectories(path))
+            var games = new ConcurrentBag<GameMetadata>();
+            var directories = Directory.GetDirectories(path);
+            Parallel.ForEach(directories, new ParallelOptions { MaxDegreeOfParallelism = libScanParallelismDegree }, folder =>
             {
                 try
                 {
@@ -239,11 +247,11 @@ namespace SteamLibrary
                 catch (Exception exc)
                 {
                     // GameMetadata.txt may not exist or may be invalid
-                    logger.Error(exc, $"Failed to get information about installed Source mod from: {path}");
+                    logger.Error(exc, $"Failed to get information about installed Source mod Path: {path}, Folder: {folder}");
                 }
-            }
+            });
 
-            return games;
+            return games.ToList();
         }
 
         internal static GameMetadata GetInstalledModFromFolder(string path, ModInfo.ModType modType)


### PR DESCRIPTION
Following #416 I Investigated what could be the cause of the very slow scan of installed games.

Since I have a lot of games installed (680~), with the almost all of them installed on a HDD, scanning the games one by one caused this delay. This can be greatly improved by scanning games in parallel.

The benefit will be most noticeable in large libraries.
These are the results:

**Current**
```
Execution 1: 846 ms
Execution 2: 749 ms
Execution 3: 690 ms
Execution 4: 708 ms
Execution 5: 652 ms
Execution 6: 657 ms
Execution 7: 720 ms
Execution 8: 677 ms
Execution 9: 685 ms
Execution 10: 695 ms
Execution 11: 738 ms
Execution 12: 734 ms
Execution 13: 754 ms
Execution 14: 699 ms
Execution 15: 642 ms
Execution 16: 678 ms
Execution 17: 695 ms
Execution 18: 647 ms
Execution 19: 646 ms
Execution 20: 671 ms
Execution 21: 692 ms
Execution 22: 724 ms
Execution 23: 680 ms
Execution 24: 719 ms
Execution 25: 725 ms
Execution 26: 656 ms
Execution 27: 684 ms
Execution 28: 689 ms
Execution 29: 667 ms
Execution 30: 697 ms
Average execution time: 697.20 ms
```

**Parallel scan with 2 parallelism**
```
Execution 1: 1763 ms
Execution 2: 342 ms
Execution 3: 334 ms
Execution 4: 332 ms
Execution 5: 337 ms
Execution 6: 337 ms
Execution 7: 334 ms
Execution 8: 334 ms
Execution 9: 337 ms
Execution 10: 364 ms
Execution 11: 348 ms
Execution 12: 347 ms
Execution 13: 425 ms
Execution 14: 393 ms
Execution 15: 378 ms
Execution 16: 346 ms
Execution 17: 344 ms
Execution 18: 338 ms
Execution 19: 356 ms
Execution 20: 364 ms
Execution 21: 346 ms
Execution 22: 352 ms
Execution 23: 353 ms
Execution 24: 351 ms
Execution 25: 347 ms
Execution 26: 348 ms
Execution 27: 360 ms
Execution 28: 367 ms
Execution 29: 358 ms
Execution 30: 341 ms
Average execution time: 399.20 ms
```

**Parallel scan with 3 parallelism**
```
Execution 1: 274 ms
Execution 2: 247 ms
Execution 3: 253 ms
Execution 4: 250 ms
Execution 5: 254 ms
Execution 6: 239 ms
Execution 7: 242 ms
Execution 8: 236 ms
Execution 9: 257 ms
Execution 10: 249 ms
Execution 11: 243 ms
Execution 12: 264 ms
Execution 13: 269 ms
Execution 14: 317 ms
Execution 15: 501 ms
Execution 16: 365 ms
Execution 17: 325 ms
Execution 18: 285 ms
Execution 19: 316 ms
Execution 20: 266 ms
Execution 21: 255 ms
Execution 22: 294 ms
Execution 23: 257 ms
Execution 24: 247 ms
Execution 25: 319 ms
Execution 26: 265 ms
Execution 27: 243 ms
Execution 28: 258 ms
Execution 29: 234 ms
Execution 30: 254 ms
Average execution time: 275.93 ms
```

---

The scans are simple and not exhaustive by any means but the benefit is evident. It's possible that SSDs could benefit from greater degrees of parallelism but that has the risk of being counter-productive in HDDs so I left it at 3 that showed great results during these tests.