### PR TITLE
Steam: Prevent "N/A" from being assigned to developers and publishers

### DIFF
--- a/source/Libraries/SteamLibrary/SteamShared/MetadataProvider.cs
+++ b/source/Libraries/SteamLibrary/SteamShared/MetadataProvider.cs
@@ -306,7 +306,7 @@ namespace Steam
                     metadata.CommunityScore = CalculateUserScore(metadata.UserReviewDetails);
                 }
 
-                publishers = metadata.StoreDetails.publishers?.Where(a => !a.IsNullOrWhiteSpace());
+                publishers = metadata.StoreDetails.publishers?.Where(a => !a.IsNullOrWhiteSpace() && !a.Equals("N/A"));
                 if (publishers.HasItems())
                 {
                     metadata.Publishers = publishers.
@@ -315,7 +315,7 @@ namespace Steam
                         ToHashSet();
                 }
 
-                developers = metadata.StoreDetails.developers?.Where(a => !a.IsNullOrWhiteSpace());
+                developers = metadata.StoreDetails.developers?.Where(a => !a.IsNullOrWhiteSpace() && !a.Equals("N/A"));
                 if (developers.HasItems())
                 {
                     metadata.Developers = developers.


### PR DESCRIPTION
Some Steam games have missing developer and/or publisher data, and have set a default "N/A" value as placeholder.

**Examples:**
- [Kimmy](https://store.steampowered.com/app/600660/Kimmy/): Missing publisher
- [Playing Both Sides](https://store.steampowered.com/app/1142090/Playing_Both_Sides/): Missing both developer and publisher

This change updates the Steam plugins to filter out "N/A" when setting the Developers and Publishers fields.