### PR TITLE
feat: import non-game extras from GOG and Humble

### DIFF
--- a/source/Libraries/AmazonGamesLibrary/Localization/en_US.xaml
+++ b/source/Libraries/AmazonGamesLibrary/Localization/en_US.xaml
@@ -20,4 +20,6 @@
   <sys:String x:Key="LOCAmazonAccountID">Account ID</sys:String>
   <sys:String x:Key="LOCAmazonGetAccountID">Get account ID</sys:String>
   <sys:String x:Key="LOCAmazonMetadataLanguageLabel">Metadata language:</sys:String>
+  <sys:String x:Key="LOCAmazonImportGameExtras">Also import non-game extras</sys:String>
+  <sys:String x:Key="LOCAmazonImportGameExtrasTooltip">Import things like soundtracks, artwork, guides as separate entries</sys:String>
 </ResourceDictionary>

--- a/source/Libraries/AmazonGamesLibrary/LocalizationKeys.cs
+++ b/source/Libraries/AmazonGamesLibrary/LocalizationKeys.cs
@@ -89,5 +89,13 @@ namespace System
         /// Metadata language:
         /// </summary>
         public const string AmazonMetadataLanguageLabel = "LOCAmazonMetadataLanguageLabel";
+        /// <summary>
+        /// Also import non-game extras
+        /// </summary>
+        public const string AmazonImportGameExtras = "LOCAmazonImportGameExtras";
+        /// <summary>
+        /// Import things like soundtracks, artwork, guides as separate entries
+        /// </summary>
+        public const string AmazonImportGameExtrasTooltip = "LOCAmazonImportGameExtrasTooltip";
     }
 }

--- a/source/Libraries/BattleNetLibrary/Localization/en_US.xaml
+++ b/source/Libraries/BattleNetLibrary/Localization/en_US.xaml
@@ -20,6 +20,8 @@
   <sys:String x:Key="LOCBattleNetAccountID">Account ID</sys:String>
   <sys:String x:Key="LOCBattleNetGetAccountID">Get account ID</sys:String>
   <sys:String x:Key="LOCBattleNetMetadataLanguageLabel">Metadata language:</sys:String>
+  <sys:String x:Key="LOCBattleNetImportGameExtras">Also import non-game extras</sys:String>
+  <sys:String x:Key="LOCBattleNetImportGameExtrasTooltip">Import things like soundtracks, artwork, guides as separate entries</sys:String>
   <!--BattleNet-->
   <sys:String x:Key="LOCBattleNetAccountSyncNotice" xml:space="preserve">Battle.net integration has long standing issue where authenticated account might get logged out at random times.
 

--- a/source/Libraries/BattleNetLibrary/LocalizationKeys.cs
+++ b/source/Libraries/BattleNetLibrary/LocalizationKeys.cs
@@ -90,6 +90,14 @@ namespace System
         /// </summary>
         public const string BattleNetMetadataLanguageLabel = "LOCBattleNetMetadataLanguageLabel";
         /// <summary>
+        /// Also import non-game extras
+        /// </summary>
+        public const string BattleNetImportGameExtras = "LOCBattleNetImportGameExtras";
+        /// <summary>
+        /// Import things like soundtracks, artwork, guides as separate entries
+        /// </summary>
+        public const string BattleNetImportGameExtrasTooltip = "LOCBattleNetImportGameExtrasTooltip";
+        /// <summary>
         /// Battle.net integration has long standing issue where authenticated account might get logged out at random times.
         /// </summary>
         public const string BattleNetAccountSyncNotice = "LOCBattleNetAccountSyncNotice";

--- a/source/Libraries/EpicLibrary/Localization/en_US.xaml
+++ b/source/Libraries/EpicLibrary/Localization/en_US.xaml
@@ -20,6 +20,8 @@
   <sys:String x:Key="LOCEpicAccountID">Account ID</sys:String>
   <sys:String x:Key="LOCEpicGetAccountID">Get account ID</sys:String>
   <sys:String x:Key="LOCEpicMetadataLanguageLabel">Metadata language:</sys:String>
+  <sys:String x:Key="LOCEpicImportGameExtras">Also import non-game extras</sys:String>
+  <sys:String x:Key="LOCEpicImportGameExtrasTooltip">Import things like soundtracks, artwork, guides as separate entries</sys:String>
   <!--Epic-->
   <sys:String x:Key="LOCEpicImportEAGames">Import EA App games</sys:String>
   <sys:String x:Key="LOCEpicImportUbisoftGames">Import Ubisoft games</sys:String>

--- a/source/Libraries/EpicLibrary/LocalizationKeys.cs
+++ b/source/Libraries/EpicLibrary/LocalizationKeys.cs
@@ -90,6 +90,14 @@ namespace System
         /// </summary>
         public const string EpicMetadataLanguageLabel = "LOCEpicMetadataLanguageLabel";
         /// <summary>
+        /// Also import non-game extras
+        /// </summary>
+        public const string EpicImportGameExtras = "LOCEpicImportGameExtras";
+        /// <summary>
+        /// Import things like soundtracks, artwork, guides as separate entries
+        /// </summary>
+        public const string EpicImportGameExtrasTooltip = "LOCEpicImportGameExtrasTooltip";
+        /// <summary>
         /// Import EA App games
         /// </summary>
         public const string EpicImportEAGames = "LOCEpicImportEAGames";

--- a/source/Libraries/GogLibrary/GogGameController.cs
+++ b/source/Libraries/GogLibrary/GogGameController.cs
@@ -67,10 +67,11 @@ namespace GogLibrary
 
         private bool HandleExtras()
         {
-            if (Game.Source.Name != GogLibrary.ExtrasSource)
+            if (!Game.GameId.StartsWith(GogLibrary.ExtrasPrefix))
             {
                 return false;
             }
+
             var url = Serialization.FromJsonFile<Dictionary<string,string>>(gogLibrary.ExtrasFile)[Game.GameId];
             ProcessStarter.StartUrl(url);
             InvokeOnInstallationCancelled(new GameInstallationCancelledEventArgs());

--- a/source/Libraries/GogLibrary/GogGameController.cs
+++ b/source/Libraries/GogLibrary/GogGameController.cs
@@ -55,21 +55,29 @@ namespace GogLibrary
 
         public override void Install(InstallActionArgs args)
         {
-            // TODO maybe move to separate plugin? set pluginId for certain games to be handled with it
-            // TODO in theory, downloading can be implemented within playnite - with progress, is-installed tracking, etc
-            var shellLink = Game.Links.FirstOrDefault(x => x.Name == "shell:open");
-            if (shellLink != null)
+            if (HandleExtras())
             {
-                Dispose();
-                ProcessStarter.StartUrl(shellLink.Url);
-                Game.IsInstalling = false;
-                Game.IsInstalled = false;
-                gogLibrary.PlayniteApi.Database.Games.Update(Game);
                 return;
             }
 
             InitiateInstall();
             StartInstallWatcher();
+        }
+
+        private bool HandleExtras()
+        {
+            var shellLink = Game.Links.FirstOrDefault(x => x.Name == "shell:open");
+            if (shellLink == null)
+            {
+                return false;
+            }
+
+            Dispose();
+            ProcessStarter.StartUrl(shellLink.Url);
+            Game.IsInstalling = false;
+            Game.IsInstalled = false;
+            gogLibrary.PlayniteApi.Database.Games.Update(Game);
+            return true;
         }
 
         private void InitiateInstall()

--- a/source/Libraries/GogLibrary/GogGameController.cs
+++ b/source/Libraries/GogLibrary/GogGameController.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Playnite;
 using Playnite.Common;
 using Playnite.SDK;
+using Playnite.SDK.Data;
 using Playnite.SDK.Models;
 using Playnite.SDK.Plugins;
 
@@ -66,17 +67,13 @@ namespace GogLibrary
 
         private bool HandleExtras()
         {
-            var shellLink = Game.Links.FirstOrDefault(x => x.Name == "shell:open");
-            if (shellLink == null)
+            if (Game.Source.Name != GogLibrary.ExtrasSource)
             {
                 return false;
             }
-
-            Dispose();
-            ProcessStarter.StartUrl(shellLink.Url);
-            Game.IsInstalling = false;
-            Game.IsInstalled = false;
-            gogLibrary.PlayniteApi.Database.Games.Update(Game);
+            var url = Serialization.FromJsonFile<Dictionary<string,string>>(gogLibrary.ExtrasFile)[Game.GameId];
+            ProcessStarter.StartUrl(url);
+            InvokeOnInstallationCancelled(new GameInstallationCancelledEventArgs());
             return true;
         }
 

--- a/source/Libraries/GogLibrary/GogGameController.cs
+++ b/source/Libraries/GogLibrary/GogGameController.cs
@@ -55,6 +55,19 @@ namespace GogLibrary
 
         public override void Install(InstallActionArgs args)
         {
+            // TODO maybe move to separate plugin? set pluginId for certain games to be handled with it
+            // TODO in theory, downloading can be implemented within playnite - with progress, is-installed tracking, etc
+            var shellLink = Game.Links.FirstOrDefault(x => x.Name == "shell:open");
+            if (shellLink != null)
+            {
+                Dispose();
+                ProcessStarter.StartUrl(shellLink.Url);
+                Game.IsInstalling = false;
+                Game.IsInstalled = false;
+                gogLibrary.PlayniteApi.Database.Games.Update(Game);
+                return;
+            }
+
             InitiateInstall();
             StartInstallWatcher();
         }

--- a/source/Libraries/GogLibrary/GogGameController.cs
+++ b/source/Libraries/GogLibrary/GogGameController.cs
@@ -72,8 +72,16 @@ namespace GogLibrary
                 return false;
             }
 
-            var url = Serialization.FromJsonFile<Dictionary<string,string>>(gogLibrary.ExtrasFile)[Game.GameId];
-            ProcessStarter.StartUrl(url);
+            try
+            {
+                var url = Serialization.FromJsonFile<Dictionary<string, string>>(gogLibrary.ExtrasFile)[Game.GameId];
+                ProcessStarter.StartUrl(url);
+            }
+            catch (Exception e)
+            {
+                throw new Exception("Missing required information for this title. Try updating GOG Library, including extras", e);
+            }
+
             InvokeOnInstallationCancelled(new GameInstallationCancelledEventArgs());
             return true;
         }

--- a/source/Libraries/GogLibrary/GogLibrary.cs
+++ b/source/Libraries/GogLibrary/GogLibrary.cs
@@ -319,7 +319,7 @@ namespace GogLibrary
         private List<GameMetadata> GetExtras(List<GameMetadata> games, GogAccountClient api)
         {
             var extras = new List<GameMetadata>();
-            var jsonData = new Dictionary<string, string>();
+            var jsonData = LoadExtrasFile();
             foreach (var game in games)
             {
                 try
@@ -340,7 +340,7 @@ namespace GogLibrary
                             Name = $"{game.Name} {x.Name.RemoveTrademarks()}"
                         };
                         extras.Add(extraAsGame);
-                        jsonData.Add(extraAsGame.GameId, $"https://www.gog.com{x.ManualUrl}");
+                        jsonData[extraAsGame.GameId] = $"https://www.gog.com{x.ManualUrl}";
                     }
                 }
                 catch (Exception e)
@@ -352,6 +352,18 @@ namespace GogLibrary
             FileSystem.PrepareSaveFile(ExtrasFile);
             File.WriteAllText(ExtrasFile, Serialization.ToJson(jsonData));
             return extras;
+        }
+
+        private Dictionary<string, string> LoadExtrasFile()
+        {
+            try
+            {
+                return Serialization.FromJsonFile<Dictionary<string, string>>(ExtrasFile);
+            }
+            catch (Exception)
+            {
+                return new Dictionary<string, string>();
+            }
         }
 
         internal IEnumerable<GameMetadata> LibraryGamesToGames(List<LibraryGameResponse> libGames)

--- a/source/Libraries/GogLibrary/GogLibrary.cs
+++ b/source/Libraries/GogLibrary/GogLibrary.cs
@@ -24,6 +24,8 @@ namespace GogLibrary
     {
         private static readonly ILogger logger = LogManager.GetLogger();
 
+        public const string ExtrasPrefix = "gog_extras";
+
         public const string ExtrasSource = "GOG Extras";
 
         public GogLibrary(IPlayniteAPI api) : base(
@@ -333,7 +335,7 @@ namespace GogLibrary
 
                         var extraAsGame = new GameMetadata()
                         {
-                            GameId = $"{game.GameId}_{id}",
+                            GameId = $"{ExtrasPrefix}_{game.GameId}_{id}",
                             Source = new MetadataNameProperty(ExtrasSource),
                             Name = $"{game.Name} {x.Name.RemoveTrademarks()}"
                         };

--- a/source/Libraries/GogLibrary/GogLibrary.cs
+++ b/source/Libraries/GogLibrary/GogLibrary.cs
@@ -322,7 +322,7 @@ namespace GogLibrary
                                     Source = new MetadataNameProperty("GOG"),
                                     Name = $"{game.Name} {x.Name.RemoveTrademarks()}",
                                     Categories = new HashSet<MetadataProperty>(){new MetadataNameProperty("extras")}, // TODO customizable category across plugins?
-                                    Links = new List<Link>(){new Link("Download_me", $"https://www.gog.com{x.ManualUrl}")} // TODO use install action to launch browser or DL with playnite itself?
+                                    Links = new List<Link>(){new Link("shell:open", $"https://www.gog.com{x.ManualUrl}")} // TODO use install action to launch browser or DL with playnite itself?
                                     // TODO any way to ignore post-actions from other plugins, eg search for metadata?
                                 };
                                 extras.Add(extraAsGame);

--- a/source/Libraries/GogLibrary/GogLibrary.cs
+++ b/source/Libraries/GogLibrary/GogLibrary.cs
@@ -298,7 +298,45 @@ namespace GogLibrary
                     Logger.Warn("Failed to obtain library stats data.");
                 }
 
-                return LibraryGamesToGames(libGames).ToList();
+                var result = LibraryGamesToGames(libGames).ToList();
+
+                if (SettingsViewModel.Settings.ImportGameExtras)
+                {
+                    var extras = new List<GameMetadata>();
+                    foreach (var game in result)
+                    {
+                        try
+                        {
+                            var gogExtras = api.GetOwnedGameDetails(game.GameId).Extras;
+                            foreach (var x in gogExtras)
+                            {
+                                var id = x.ManualUrl.Split('/').Last();
+                                if (!long.TryParse(id, out _))
+                                {
+                                    continue;
+                                }
+
+                                var extraAsGame = new GameMetadata()
+                                {
+                                    GameId = $"{game.GameId}_{id}",
+                                    Source = new MetadataNameProperty("GOG"),
+                                    Name = $"{game.Name} {x.Name.RemoveTrademarks()}",
+                                    Categories = new HashSet<MetadataProperty>(){new MetadataNameProperty("extras")}, // TODO customizable category across plugins?
+                                    Links = new List<Link>(){new Link("Download_me", $"https://www.gog.com{x.ManualUrl}")} // TODO use install action to launch browser or DL with playnite itself?
+                                    // TODO any way to ignore post-actions from other plugins, eg search for metadata?
+                                };
+                                extras.Add(extraAsGame);
+                            }
+                        }
+                        catch (Exception e)
+                        {
+                            logger.Error(e, $"Failed to get extras for gog game: {game.GameId} {game.Name}.");
+                        }
+                    }
+                    result.AddRange(extras);
+                }
+
+                return result;
             }
         }
 

--- a/source/Libraries/GogLibrary/GogLibrary.csproj
+++ b/source/Libraries/GogLibrary/GogLibrary.csproj
@@ -37,8 +37,8 @@
     <Reference Include="AngleSharp, Version=0.9.9.0, Culture=neutral, PublicKeyToken=e83494dcdc6d31ea, processorArchitecture=MSIL">
       <HintPath>..\..\packages\AngleSharp.0.9.9\lib\net45\AngleSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Playnite.SDK, Version=6.13.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>C:\vault\playniteCancel\Playnite.SDK.dll</HintPath>
+    <Reference Include="Playnite.SDK, Version=6.14.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\PlayniteSDK.6.14.0\lib\net462\Playnite.SDK.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/source/Libraries/GogLibrary/GogLibrary.csproj
+++ b/source/Libraries/GogLibrary/GogLibrary.csproj
@@ -37,8 +37,8 @@
     <Reference Include="AngleSharp, Version=0.9.9.0, Culture=neutral, PublicKeyToken=e83494dcdc6d31ea, processorArchitecture=MSIL">
       <HintPath>..\..\packages\AngleSharp.0.9.9\lib\net45\AngleSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Playnite.SDK, Version=6.4.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\PlayniteSDK.6.4.0\lib\net462\Playnite.SDK.dll</HintPath>
+    <Reference Include="Playnite.SDK, Version=6.13.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>C:\vault\playniteCancel\Playnite.SDK.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/source/Libraries/GogLibrary/GogLibrary.csproj
+++ b/source/Libraries/GogLibrary/GogLibrary.csproj
@@ -177,6 +177,7 @@
     <Compile Include="Models\GogGameTaskInfo.cs" />
     <Compile Include="Models\GetOwnedGamesResult.cs" />
     <Compile Include="Models\LibraryGameResponse.cs" />
+    <Compile Include="Models\OwnedGameDetailsResponse.cs" />
     <Compile Include="Models\PagedResponse.cs" />
     <Compile Include="Models\ProductApiDetail.cs" />
     <Compile Include="Models\StoreGamesFilteredListResponse.cs" />

--- a/source/Libraries/GogLibrary/GogLibrarySettingsView.xaml
+++ b/source/Libraries/GogLibrary/GogLibrarySettingsView.xaml
@@ -1,8 +1,8 @@
 ﻿<UserControl x:Class="GogLibrary.GogLibrarySettingsView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:local="clr-namespace:GogLibrary"
              xmlns:sys="clr-namespace:System;assembly=mscorlib"
              xmlns:pcon="clr-namespace:Playnite.Converters"
@@ -36,7 +36,7 @@
                       Content="{DynamicResource LOCGOGSettingsImportUninstalledLabel}"/>
 
             <StackPanel Orientation="Horizontal" Margin="0,10,0,10">
-                <Button Content="{DynamicResource LOCGOGAuthenticateLabel}" HorizontalAlignment="Left"                         
+                <Button Content="{DynamicResource LOCGOGAuthenticateLabel}" HorizontalAlignment="Left"
                         Command="{Binding LoginCommand}" Margin="0,5,5,5"/>
                 <TextBlock VerticalAlignment="Center" Margin="10,5,5,5">
                     <TextBlock.Tag>
@@ -72,6 +72,8 @@
                   Visibility="{Binding IsFirstRunUse, Converter={pcon:InvertedBooleanToVisibilityConverter}}"/>
         <CheckBox IsChecked="{Binding Settings.UseVerticalCovers}" DockPanel.Dock="Top"
                   Content="{DynamicResource LOCGOGSettingsUseVerticalCovers}"/>
+        <CheckBox IsChecked="{Binding Settings.ImportGameExtras}" DockPanel.Dock="Top"
+                  Content="{DynamicResource LOCGOGSettingsImportGameExtras}"/>
 
         <StackPanel Orientation="Horizontal" Margin="0,10,0,0"
                     Visibility="{Binding IsFirstRunUse, Converter={pcon:InvertedBooleanToVisibilityConverter}}">

--- a/source/Libraries/GogLibrary/GogLibrarySettingsView.xaml
+++ b/source/Libraries/GogLibrary/GogLibrarySettingsView.xaml
@@ -75,7 +75,7 @@
         <CheckBox IsChecked="{Binding Settings.ImportGameExtras}" DockPanel.Dock="Top" Margin="0,15"
                   Content="{DynamicResource LOCImportGameExtras}"
                   ToolTip="{DynamicResource LOCImportGameExtrasTooltip}"
-                  />
+                  Visibility="{Binding IsFirstRunUse, Converter={pcon:InvertedBooleanToVisibilityConverter}}"/>
 
         <StackPanel Orientation="Horizontal" Margin="0,10,0,0"
                     Visibility="{Binding IsFirstRunUse, Converter={pcon:InvertedBooleanToVisibilityConverter}}">

--- a/source/Libraries/GogLibrary/GogLibrarySettingsView.xaml
+++ b/source/Libraries/GogLibrary/GogLibrarySettingsView.xaml
@@ -72,7 +72,7 @@
                   Visibility="{Binding IsFirstRunUse, Converter={pcon:InvertedBooleanToVisibilityConverter}}"/>
         <CheckBox IsChecked="{Binding Settings.UseVerticalCovers}" DockPanel.Dock="Top"
                   Content="{DynamicResource LOCGOGSettingsUseVerticalCovers}"/>
-        <CheckBox IsChecked="{Binding Settings.ImportGameExtras}" DockPanel.Dock="Top"
+        <CheckBox IsChecked="{Binding Settings.ImportGameExtras}" DockPanel.Dock="Top" Margin="0,15"
                   Content="{DynamicResource LOCGOGSettingsImportGameExtras}"/>
 
         <StackPanel Orientation="Horizontal" Margin="0,10,0,0"

--- a/source/Libraries/GogLibrary/GogLibrarySettingsView.xaml
+++ b/source/Libraries/GogLibrary/GogLibrarySettingsView.xaml
@@ -73,7 +73,9 @@
         <CheckBox IsChecked="{Binding Settings.UseVerticalCovers}" DockPanel.Dock="Top"
                   Content="{DynamicResource LOCGOGSettingsUseVerticalCovers}"/>
         <CheckBox IsChecked="{Binding Settings.ImportGameExtras}" DockPanel.Dock="Top" Margin="0,15"
-                  Content="{DynamicResource LOCGOGSettingsImportGameExtras}"/>
+                  Content="{DynamicResource LOCImportGameExtras}"
+                  ToolTip="{DynamicResource LOCImportGameExtrasTooltip}"
+                  />
 
         <StackPanel Orientation="Horizontal" Margin="0,10,0,0"
                     Visibility="{Binding IsFirstRunUse, Converter={pcon:InvertedBooleanToVisibilityConverter}}">

--- a/source/Libraries/GogLibrary/GogLibrarySettingsView.xaml
+++ b/source/Libraries/GogLibrary/GogLibrarySettingsView.xaml
@@ -73,8 +73,8 @@
         <CheckBox IsChecked="{Binding Settings.UseVerticalCovers}" DockPanel.Dock="Top"
                   Content="{DynamicResource LOCGOGSettingsUseVerticalCovers}"/>
         <CheckBox IsChecked="{Binding Settings.ImportGameExtras}" DockPanel.Dock="Top" Margin="0,15"
-                  Content="{DynamicResource LOCImportGameExtras}"
-                  ToolTip="{DynamicResource LOCImportGameExtrasTooltip}"
+                  Content="{DynamicResource LOCGOGImportGameExtras}"
+                  ToolTip="{DynamicResource LOCGOGImportGameExtrasTooltip}"
                   Visibility="{Binding IsFirstRunUse, Converter={pcon:InvertedBooleanToVisibilityConverter}}"/>
 
         <StackPanel Orientation="Horizontal" Margin="0,10,0,0"

--- a/source/Libraries/GogLibrary/GogLibrarySettingsViewModel.cs
+++ b/source/Libraries/GogLibrary/GogLibrarySettingsViewModel.cs
@@ -14,7 +14,7 @@ namespace GogLibrary
         public bool StartGamesUsingGalaxy { get; set; } = false;
         public bool UseAutomaticGameInstalls { get; set; } = false;
         public bool UseVerticalCovers { get; set; } = true;
-        public bool ImportGameExtras { get; set; } = false;
+        public bool ImportGameExtras { get; set; } = true;
         public string Locale { get; set; } = "en";
     }
     public class GogLibrarySettingsViewModel : PluginSettingsViewModel<GogLibrarySettings, GogLibrary>

--- a/source/Libraries/GogLibrary/GogLibrarySettingsViewModel.cs
+++ b/source/Libraries/GogLibrary/GogLibrarySettingsViewModel.cs
@@ -14,6 +14,7 @@ namespace GogLibrary
         public bool StartGamesUsingGalaxy { get; set; } = false;
         public bool UseAutomaticGameInstalls { get; set; } = false;
         public bool UseVerticalCovers { get; set; } = true;
+        public bool ImportGameExtras { get; set; } = false;
         public string Locale { get; set; } = "en";
     }
     public class GogLibrarySettingsViewModel : PluginSettingsViewModel<GogLibrarySettings, GogLibrary>

--- a/source/Libraries/GogLibrary/GogLibrarySettingsViewModel.cs
+++ b/source/Libraries/GogLibrary/GogLibrarySettingsViewModel.cs
@@ -14,7 +14,7 @@ namespace GogLibrary
         public bool StartGamesUsingGalaxy { get; set; } = false;
         public bool UseAutomaticGameInstalls { get; set; } = false;
         public bool UseVerticalCovers { get; set; } = true;
-        public bool ImportGameExtras { get; set; } = true;
+        public bool ImportGameExtras { get; set; } = false;
         public string Locale { get; set; } = "en";
     }
     public class GogLibrarySettingsViewModel : PluginSettingsViewModel<GogLibrarySettings, GogLibrary>

--- a/source/Libraries/GogLibrary/Localization/en_US.xaml
+++ b/source/Libraries/GogLibrary/Localization/en_US.xaml
@@ -20,8 +20,8 @@
   <sys:String x:Key="LOCGOGAccountID">Account ID</sys:String>
   <sys:String x:Key="LOCGOGGetAccountID">Get account ID</sys:String>
   <sys:String x:Key="LOCGOGMetadataLanguageLabel">Metadata language:</sys:String>
-  <sys:String x:Key="LOCImportGameExtras">Also import non-game extras</sys:String>
-  <sys:String x:Key="LOCImportGameExtrasTooltip">Import things like soundtracks, artwork, guides as separate entries</sys:String>
+  <sys:String x:Key="LOCGOGImportGameExtras">Also import non-game extras</sys:String>
+  <sys:String x:Key="LOCGOGImportGameExtrasTooltip">Import things like soundtracks, artwork, guides as separate entries</sys:String>
   <!--GOG-->
   <sys:String x:Key="LOCGOGUseLogin">Account Login</sys:String>
   <sys:String x:Key="LOCGOGUseAccountName">Account Name</sys:String>

--- a/source/Libraries/GogLibrary/Localization/en_US.xaml
+++ b/source/Libraries/GogLibrary/Localization/en_US.xaml
@@ -20,6 +20,8 @@
   <sys:String x:Key="LOCGOGAccountID">Account ID</sys:String>
   <sys:String x:Key="LOCGOGGetAccountID">Get account ID</sys:String>
   <sys:String x:Key="LOCGOGMetadataLanguageLabel">Metadata language:</sys:String>
+  <sys:String x:Key="LOCImportGameExtras">Also import non-game extras</sys:String>
+  <sys:String x:Key="LOCImportGameExtrasTooltip">Import things like soundtracks, artwork, guides as separate entries</sys:String>
   <!--GOG-->
   <sys:String x:Key="LOCGOGUseLogin">Account Login</sys:String>
   <sys:String x:Key="LOCGOGUseAccountName">Account Name</sys:String>
@@ -31,5 +33,4 @@ Note that the Account Name option only works for accounts whose game libraries h
   <sys:String x:Key="LOCGOGSettingsUseAutomaticGameInstallsTooltip" xml:space="preserve">If enabled, the install process will be automatically started without needing user interaction to the configured default install location.
 If disabled, the game page will be opened to manually start the install process.</sys:String>
   <sys:String x:Key="LOCGOGSettingsUseVerticalCovers">Use vertical covers</sys:String>
-  <sys:String x:Key="LOCGOGSettingsImportGameExtras">Also import game extras</sys:String>
 </ResourceDictionary>

--- a/source/Libraries/GogLibrary/Localization/en_US.xaml
+++ b/source/Libraries/GogLibrary/Localization/en_US.xaml
@@ -31,4 +31,5 @@ Note that the Account Name option only works for accounts whose game libraries h
   <sys:String x:Key="LOCGOGSettingsUseAutomaticGameInstallsTooltip" xml:space="preserve">If enabled, the install process will be automatically started without needing user interaction to the configured default install location.
 If disabled, the game page will be opened to manually start the install process.</sys:String>
   <sys:String x:Key="LOCGOGSettingsUseVerticalCovers">Use vertical covers</sys:String>
+  <sys:String x:Key="LOCGOGSettingsImportGameExtras">Also import game extras</sys:String>
 </ResourceDictionary>

--- a/source/Libraries/GogLibrary/LocalizationKeys.cs
+++ b/source/Libraries/GogLibrary/LocalizationKeys.cs
@@ -1,6 +1,6 @@
 ///
 /// DO NOT MODIFY! Automatically generated via UpdateLocExtFiles.ps1 script.
-///
+/// 
 namespace System
 {
     public static class LOC
@@ -89,6 +89,14 @@ namespace System
         /// Metadata language:
         /// </summary>
         public const string GOGMetadataLanguageLabel = "LOCGOGMetadataLanguageLabel";
+        /// <summary>
+        /// Also import non-game extras
+        /// </summary>
+        public const string GOGImportGameExtras = "LOCGOGImportGameExtras";
+        /// <summary>
+        /// Import things like soundtracks, artwork, guides as separate entries
+        /// </summary>
+        public const string GOGImportGameExtrasTooltip = "LOCGOGImportGameExtrasTooltip";
         /// <summary>
         /// Account Login
         /// </summary>

--- a/source/Libraries/GogLibrary/LocalizationKeys.cs
+++ b/source/Libraries/GogLibrary/LocalizationKeys.cs
@@ -121,9 +121,5 @@ namespace System
         /// Use vertical covers
         /// </summary>
         public const string GOGSettingsUseVerticalCovers = "LOCGOGSettingsUseVerticalCovers";
-        /// <summary>
-        /// Import game extras (soundtracks, artwork, guides, ...) when importing games
-        /// </summary>
-        public const string GOGSettingsImportGameExtras = "LOCGOGSettingsImportGameExtras";
     }
 }

--- a/source/Libraries/GogLibrary/LocalizationKeys.cs
+++ b/source/Libraries/GogLibrary/LocalizationKeys.cs
@@ -1,6 +1,6 @@
 ///
 /// DO NOT MODIFY! Automatically generated via UpdateLocExtFiles.ps1 script.
-/// 
+///
 namespace System
 {
     public static class LOC
@@ -121,5 +121,9 @@ namespace System
         /// Use vertical covers
         /// </summary>
         public const string GOGSettingsUseVerticalCovers = "LOCGOGSettingsUseVerticalCovers";
+        /// <summary>
+        /// Import game extras (soundtracks, artwork, guides, ...) when importing games
+        /// </summary>
+        public const string GOGSettingsImportGameExtras = "LOCGOGSettingsImportGameExtras";
     }
 }

--- a/source/Libraries/GogLibrary/Models/OwnedGameDetailsResponse.cs
+++ b/source/Libraries/GogLibrary/Models/OwnedGameDetailsResponse.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+
+namespace GogLibrary.Models
+{
+    public class OwnedGameDetailsResponse
+    {
+        /// <example>The Witcher 3: Wild Hunt - Complete Edition</example>>
+        public string Title { get; set; }
+
+        public List<Extra> Extras { get; set; }
+    }
+
+    public class Extra
+    {
+        /// <example>/downloads/the_witcher_3_wild_hunt_game_of_the_year_edition_game/70003</example>
+        public string ManualUrl { get; set; }
+
+        /// <example>soundtrack (MP3)</example>
+        public string Name { get; set; }
+
+        /// <example>audio</example>
+        public string Type { get; set; }
+
+        /// <summary>
+        /// number of items in downloaded archive, displayed in UI like "paper toys (6)". not shown when equals 1 or 2.
+        /// </summary>
+        /// <example>1</example>
+        public long Info { get; set; }
+
+        /// <example>206 MB</example>
+        /// <example>4096 MB</example>
+        public string Size { get; set; }
+    }
+}

--- a/source/Libraries/GogLibrary/Services/GogAccountClient.cs
+++ b/source/Libraries/GogLibrary/Services/GogAccountClient.cs
@@ -151,5 +151,13 @@ namespace GogLibrary.Services
 
             return games;
         }
+
+        public OwnedGameDetailsResponse GetOwnedGameDetails(string gameId)
+        {
+            webView.NavigateAndWait($@"https://www.gog.com/account/gameDetails/{gameId}.json");
+            var stringInfo = webView.GetPageText();
+            var response = Serialization.FromJson<OwnedGameDetailsResponse>(stringInfo);
+            return response;
+        }
     }
 }

--- a/source/Libraries/GogLibrary/packages.config
+++ b/source/Libraries/GogLibrary/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AngleSharp" version="0.9.9" targetFramework="net462" />
-  <package id="PlayniteSDK" version="6.4.0" targetFramework="net462" />
+  <package id="PlayniteSDK" version="6.14.0" targetFramework="net462" />
 </packages>

--- a/source/Libraries/HumbleLibrary/HumbleGameController.cs
+++ b/source/Libraries/HumbleLibrary/HumbleGameController.cs
@@ -31,6 +31,19 @@ namespace HumbleLibrary
 
         public override void Install(InstallActionArgs args)
         {
+            // TODO maybe move to separate plugin? set pluginId for certain games to be handled with it
+            // TODO in theory, downloading can be implemented within playnite - with progress, is-installed tracking, etc
+            var shellLink = Game.Links.FirstOrDefault(x => x.Name == "shell:open");
+            if (shellLink != null)
+            {
+                Dispose();
+                ProcessStarter.StartUrl(shellLink.Url);
+                Game.IsInstalling = false;
+                Game.IsInstalled = false;
+                library.PlayniteApi.Database.Games.Update(Game);
+                return;
+            }
+
             if (Game.SupportsHumbleApp())
             {
                 Dispose();

--- a/source/Libraries/HumbleLibrary/HumbleGameController.cs
+++ b/source/Libraries/HumbleLibrary/HumbleGameController.cs
@@ -91,13 +91,21 @@ namespace HumbleLibrary
                 return false;
             }
 
-            var str = Encryption.DecryptFromFile(
-                library.ExtrasFile,
-                Encoding.UTF8,
-                WindowsIdentity.GetCurrent().User.Value);
-            var extra = Serialization.FromJson<Dictionary<string, Extra>>(str)[Game.GameId];
-            var url = GetExtraUrl(extra);
-            ProcessStarter.StartUrl(url);
+            try
+            {
+                var str = Encryption.DecryptFromFile(
+                    library.ExtrasFile,
+                    Encoding.UTF8,
+                    WindowsIdentity.GetCurrent().User.Value);
+                var extra = Serialization.FromJson<Dictionary<string, Extra>>(str)[Game.GameId];
+                var url = GetExtraUrl(extra);
+                ProcessStarter.StartUrl(url);
+            }
+            catch (Exception e)
+            {
+                throw new Exception("Missing required information for this title, or Humble client failed. Try updating Humble Library, including extras", e);
+            }
+
             InvokeOnInstallationCancelled(new GameInstallationCancelledEventArgs());
             return true;
         }

--- a/source/Libraries/HumbleLibrary/HumbleGameController.cs
+++ b/source/Libraries/HumbleLibrary/HumbleGameController.cs
@@ -6,12 +6,14 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
+using System.Security.Principal;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using HumbleLibrary.Models;
 using HumbleLibrary.Services;
 using Playnite.SDK.Data;
+using PlayniteExtensions.Common;
 
 namespace HumbleLibrary
 {
@@ -84,11 +86,16 @@ namespace HumbleLibrary
 
         private bool HandleExtras()
         {
-            if (Game.Source.Name != HumbleLibrary.ExtrasSource)
+            if (!Game.GameId.StartsWith(HumbleLibrary.ExtrasPrefix))
             {
                 return false;
             }
-            var extra = Serialization.FromJsonFile<Dictionary<string,Extra>>(library.ExtrasFile)[Game.GameId];
+
+            var str = Encryption.DecryptFromFile(
+                library.ExtrasFile,
+                Encoding.UTF8,
+                WindowsIdentity.GetCurrent().User.Value);
+            var extra = Serialization.FromJson<Dictionary<string, Extra>>(str)[Game.GameId];
             var url = GetExtraUrl(extra);
             ProcessStarter.StartUrl(url);
             InvokeOnInstallationCancelled(new GameInstallationCancelledEventArgs());

--- a/source/Libraries/HumbleLibrary/HumbleGameController.cs
+++ b/source/Libraries/HumbleLibrary/HumbleGameController.cs
@@ -31,16 +31,8 @@ namespace HumbleLibrary
 
         public override void Install(InstallActionArgs args)
         {
-            // TODO maybe move to separate plugin? set pluginId for certain games to be handled with it
-            // TODO in theory, downloading can be implemented within playnite - with progress, is-installed tracking, etc
-            var shellLink = Game.Links.FirstOrDefault(x => x.Name == "shell:open");
-            if (shellLink != null)
+            if (HandleExtras())
             {
-                Dispose();
-                ProcessStarter.StartUrl(shellLink.Url);
-                Game.IsInstalling = false;
-                Game.IsInstalled = false;
-                library.PlayniteApi.Database.Games.Update(Game);
                 return;
             }
 
@@ -85,6 +77,22 @@ namespace HumbleLibrary
 
                 throw new Exception(ResourceProvider.GetString(LOC.HumbleNonTroveInstallError));
             }
+        }
+
+        private bool HandleExtras()
+        {
+            var shellLink = Game.Links.FirstOrDefault(x => x.Name == "shell:open");
+            if (shellLink == null)
+            {
+                return false;
+            }
+
+            Dispose();
+            ProcessStarter.StartUrl(shellLink.Url);
+            Game.IsInstalling = false;
+            Game.IsInstalled = false;
+            library.PlayniteApi.Database.Games.Update(Game);
+            return true;
         }
 
         public async void StartInstallWatcher()

--- a/source/Libraries/HumbleLibrary/HumbleGameController.cs
+++ b/source/Libraries/HumbleLibrary/HumbleGameController.cs
@@ -129,7 +129,7 @@ namespace HumbleLibrary
                 var actualDownload = order.subproducts
                     .SelectMany(x => x.downloads)
                     .SelectMany(x => x.download_struct)
-                    .Single(x => x.sha1 == extra.Sha1);
+                    .Single(x => x.md5 == extra.Md5);
                 return actualDownload.url.web;
             }
         }

--- a/source/Libraries/HumbleLibrary/HumbleLibrary.cs
+++ b/source/Libraries/HumbleLibrary/HumbleLibrary.cs
@@ -226,7 +226,7 @@ namespace HumbleLibrary
         public List<GameMetadata> GetLibraryExtras(List<Order> orders)
         {
             var extras = new List<GameMetadata>();
-            var jsonData = new Dictionary<string, Extra>();
+            var jsonData = LoadExtrasFile();
             foreach (var order in orders)
             {
                 var gameKey = order.gamekey;
@@ -267,10 +267,10 @@ namespace HumbleLibrary
                                     Name = $"{subproductHumanName} asm.js version ({order.product.human_name})"
                                 };
                                 extras.Add(extraAsGame);
-                                jsonData.Add(extraAsGame.GameId, new Extra
+                                jsonData[extraAsGame.GameId] = new Extra
                                 {
                                     PermanentUrl = $"https://www.humblebundle.com/play/asmjs/{downloadName}/{gameKey}"
-                                });
+                                };
                                 continue;
                         }
 
@@ -283,11 +283,11 @@ namespace HumbleLibrary
                                 Name = $"{subproductHumanName} {download.platform} {actualDownload.name} ({order.product.human_name})"
                             };
                             extras.Add(extraAsGame);
-                            jsonData.Add(extraAsGame.GameId, new Extra
+                            jsonData[extraAsGame.GameId] = new Extra
                             {
                                 GameKey = gameKey,
                                 Sha1 = actualDownload.sha1
-                            });
+                            };
                         }
                     }
                 }
@@ -300,6 +300,22 @@ namespace HumbleLibrary
                 Encoding.UTF8,
                 WindowsIdentity.GetCurrent().User.Value);
             return extras;
+        }
+
+        private Dictionary<string, Extra> LoadExtrasFile()
+        {
+            try
+            {
+                var str = Encryption.DecryptFromFile(
+                    ExtrasFile,
+                    Encoding.UTF8,
+                    WindowsIdentity.GetCurrent().User.Value);
+                return Serialization.FromJson<Dictionary<string, Extra>>(str);
+            }
+            catch (Exception)
+            {
+                return new Dictionary<string, Extra>();
+            }
         }
 
         private List<Order> GetAllOrders()

--- a/source/Libraries/HumbleLibrary/HumbleLibrary.cs
+++ b/source/Libraries/HumbleLibrary/HumbleLibrary.cs
@@ -253,9 +253,8 @@ namespace HumbleLibrary
                                     GameId = $"{productName}_{downloadName}",
                                     Source = new MetadataNameProperty("Humble"),
                                     Name = $"{productName} asm.js version",
-                                    Categories = new HashSet<MetadataProperty>(){new MetadataNameProperty("extras")}, // TODO customizable category across plugins?
-                                    Links = new List<Link>(){new Link("shell:open", $"https://www.humblebundle.com/play/asmjs/{downloadName}/{gameKey}")} // TODO use install action to launch browser?
-                                    // TODO any way to ignore post-actions from other plugins, eg search for metadata?
+                                    Categories = new HashSet<MetadataProperty>(){new MetadataNameProperty("extras")},
+                                    Links = new List<Link>(){new Link("shell:open", $"https://www.humblebundle.com/play/asmjs/{downloadName}/{gameKey}")}
                                 };
                                 extras.Add(extraAsGame);
                                 continue;
@@ -273,9 +272,8 @@ namespace HumbleLibrary
                                 GameId = $"{productName}_{downloadName}_{actualDownload.name}",
                                 Source = new MetadataNameProperty("Humble"),
                                 Name = $"{productName} {download.platform} {actualDownload.name}",
-                                Categories = new HashSet<MetadataProperty>(){new MetadataNameProperty("extras")}, // TODO customizable category across plugins?
-                                Links = new List<Link>(){new Link("shell:open", url)} // TODO use install action to launch browser or DL with playnite itself?
-                                // TODO any way to ignore post-actions from other plugins, eg search for metadata?
+                                Categories = new HashSet<MetadataProperty>(){new MetadataNameProperty("extras")},
+                                Links = new List<Link>(){new Link("shell:open", url)}
                             };
                             extras.Add(extraAsGame);
                         }

--- a/source/Libraries/HumbleLibrary/HumbleLibrary.cs
+++ b/source/Libraries/HumbleLibrary/HumbleLibrary.cs
@@ -286,7 +286,7 @@ namespace HumbleLibrary
                             jsonData[extraAsGame.GameId] = new Extra
                             {
                                 GameKey = gameKey,
-                                Sha1 = actualDownload.sha1
+                                Md5 = actualDownload.md5
                             };
                         }
                     }

--- a/source/Libraries/HumbleLibrary/HumbleLibrary.cs
+++ b/source/Libraries/HumbleLibrary/HumbleLibrary.cs
@@ -254,7 +254,7 @@ namespace HumbleLibrary
                                     Source = new MetadataNameProperty("Humble"),
                                     Name = $"{productName} asm.js version",
                                     Categories = new HashSet<MetadataProperty>(){new MetadataNameProperty("extras")}, // TODO customizable category across plugins?
-                                    Links = new List<Link>(){new Link("Run_me", $"https://www.humblebundle.com/play/asmjs/{downloadName}/{gameKey}")} // TODO use install action to launch browser?
+                                    Links = new List<Link>(){new Link("shell:open", $"https://www.humblebundle.com/play/asmjs/{downloadName}/{gameKey}")} // TODO use install action to launch browser?
                                     // TODO any way to ignore post-actions from other plugins, eg search for metadata?
                                 };
                                 extras.Add(extraAsGame);
@@ -274,7 +274,7 @@ namespace HumbleLibrary
                                 Source = new MetadataNameProperty("Humble"),
                                 Name = $"{productName} {download.platform} {actualDownload.name}",
                                 Categories = new HashSet<MetadataProperty>(){new MetadataNameProperty("extras")}, // TODO customizable category across plugins?
-                                Links = new List<Link>(){new Link("Download_me", url)} // TODO use install action to launch browser or DL with playnite itself?
+                                Links = new List<Link>(){new Link("shell:open", url)} // TODO use install action to launch browser or DL with playnite itself?
                                 // TODO any way to ignore post-actions from other plugins, eg search for metadata?
                             };
                             extras.Add(extraAsGame);

--- a/source/Libraries/HumbleLibrary/HumbleLibrary.csproj
+++ b/source/Libraries/HumbleLibrary/HumbleLibrary.csproj
@@ -38,8 +38,8 @@
     <Reference Include="AngleSharp, Version=0.9.9.0, Culture=neutral, PublicKeyToken=e83494dcdc6d31ea, processorArchitecture=MSIL">
       <HintPath>..\..\packages\AngleSharp.0.9.9\lib\net45\AngleSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Playnite.SDK, Version=6.2.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\PlayniteSDK.6.2.2\lib\net462\Playnite.SDK.dll</HintPath>
+    <Reference Include="Playnite.SDK, Version=6.13.0.0, Culture=neutral, processorArchitecture=MSIL">
+        <HintPath>C:\vault\playniteCancel\Playnite.SDK.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
@@ -164,6 +164,7 @@
       <DependentUpon>HumbleLibrarySettingsView.xaml</DependentUpon>
     </Compile>
     <Compile Include="LocalizationKeys.cs" />
+    <Compile Include="Models\Extra.cs" />
     <Compile Include="Models\HumbleApp.cs" />
     <Compile Include="Models\Order.cs" />
     <Compile Include="Models\Trove.cs" />

--- a/source/Libraries/HumbleLibrary/HumbleLibrary.csproj
+++ b/source/Libraries/HumbleLibrary/HumbleLibrary.csproj
@@ -38,8 +38,8 @@
     <Reference Include="AngleSharp, Version=0.9.9.0, Culture=neutral, PublicKeyToken=e83494dcdc6d31ea, processorArchitecture=MSIL">
       <HintPath>..\..\packages\AngleSharp.0.9.9\lib\net45\AngleSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Playnite.SDK, Version=6.13.0.0, Culture=neutral, processorArchitecture=MSIL">
-        <HintPath>C:\vault\playniteCancel\Playnite.SDK.dll</HintPath>
+    <Reference Include="Playnite.SDK, Version=6.14.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\PlayniteSDK.6.14.0\lib\net462\Playnite.SDK.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/source/Libraries/HumbleLibrary/HumbleLibrary.csproj
+++ b/source/Libraries/HumbleLibrary/HumbleLibrary.csproj
@@ -155,6 +155,9 @@
     <Compile Include="..\..\Generic\PlayniteExtensions.Common\PluginSettingsViewModel.cs">
       <Link>Shared\PluginSettingsViewModel.cs</Link>
     </Compile>
+    <Compile Include="..\..\Generic\PlayniteExtensions.Common\Encryption.cs">
+      <Link>Shared\Encryption.cs</Link>
+    </Compile>
     <Compile Include="HumbleClient.cs" />
     <Compile Include="HumbleGameController.cs" />
     <Compile Include="HumbleLibraryClient.cs" />
@@ -199,6 +202,5 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/source/Libraries/HumbleLibrary/HumbleLibrarySettingsView.xaml
+++ b/source/Libraries/HumbleLibrary/HumbleLibrarySettingsView.xaml
@@ -28,10 +28,6 @@
                       IsChecked="{Binding Settings.ImportGeneralLibrary}"
                       Content="{DynamicResource LOCHumbleGeneralLibrary}"
                       ToolTip="{DynamicResource LOCHumbleGeneralLibraryTooltip}" />
-            <CheckBox Margin="0,10,0,0" Name="HumbleImportGameExtras"
-                      IsChecked="{Binding Settings.ImportGameExtras}"
-                      Content="{DynamicResource LOCHumbleImportGameExtras}"
-                      ToolTip="{DynamicResource LOCHumbleImportGameExtrasTooltip}" />
             <StackPanel IsEnabled="{Binding IsChecked, ElementName=HumbleImportGeneralLibrary}">
                 <CheckBox Margin="20,10,0,0" Name="HumbleThirdPartyImport"
                       IsChecked="{Binding Settings.IgnoreThirdPartyStoreGames}"
@@ -43,6 +39,10 @@
                       Content="{DynamicResource LOCHumbleImportThirdPartyDrmFree}"
                       ToolTip="{DynamicResource LOCHumbleImportThirdPartyDrmFreeTooltip}"/>
             </StackPanel>
+            <CheckBox Margin="0,10,0,0" Name="HumbleImportGameExtras"
+                      IsChecked="{Binding Settings.ImportGameExtras}"
+                      Content="{DynamicResource LOCHumbleImportGameExtras}"
+                      ToolTip="{DynamicResource LOCHumbleImportGameExtrasTooltip}" />
             <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
                 <Button Content="{DynamicResource LOCHumbleAuthenticateLabel}" HorizontalAlignment="Left"
                         Command="{Binding LoginCommand}" Margin="0,5,5,5"/>

--- a/source/Libraries/HumbleLibrary/HumbleLibrarySettingsView.xaml
+++ b/source/Libraries/HumbleLibrary/HumbleLibrarySettingsView.xaml
@@ -41,8 +41,8 @@
             </StackPanel>
             <CheckBox Margin="0,10,0,0" Name="HumbleImportGameExtras"
                       IsChecked="{Binding Settings.ImportGameExtras}"
-                      Content="{DynamicResource LOCHumbleImportGameExtras}"
-                      ToolTip="{DynamicResource LOCHumbleImportGameExtrasTooltip}" />
+                      Content="{DynamicResource LOCImportGameExtras}"
+                      ToolTip="{DynamicResource LOCImportGameExtrasTooltip}" />
             <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
                 <Button Content="{DynamicResource LOCHumbleAuthenticateLabel}" HorizontalAlignment="Left"
                         Command="{Binding LoginCommand}" Margin="0,5,5,5"/>

--- a/source/Libraries/HumbleLibrary/HumbleLibrarySettingsView.xaml
+++ b/source/Libraries/HumbleLibrary/HumbleLibrarySettingsView.xaml
@@ -42,8 +42,8 @@
             </StackPanel>
             <CheckBox Margin="0,10,0,0" Name="HumbleImportGameExtras"
                       IsChecked="{Binding Settings.ImportGameExtras}"
-                      Content="{DynamicResource LOCImportGameExtras}"
-                      ToolTip="{DynamicResource LOCImportGameExtrasTooltip}"
+                      Content="{DynamicResource LOCHumbleImportGameExtras}"
+                      ToolTip="{DynamicResource LOCHumbleImportGameExtrasTooltip}"
                       Visibility="{Binding IsFirstRunUse, Converter={pcon:InvertedBooleanToVisibilityConverter}}"/>
             <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
                 <Button Content="{DynamicResource LOCHumbleAuthenticateLabel}" HorizontalAlignment="Left"

--- a/source/Libraries/HumbleLibrary/HumbleLibrarySettingsView.xaml
+++ b/source/Libraries/HumbleLibrary/HumbleLibrarySettingsView.xaml
@@ -28,6 +28,10 @@
                       IsChecked="{Binding Settings.ImportGeneralLibrary}"
                       Content="{DynamicResource LOCHumbleGeneralLibrary}"
                       ToolTip="{DynamicResource LOCHumbleGeneralLibraryTooltip}" />
+            <CheckBox Margin="0,10,0,0" Name="HumbleImportGameExtras"
+                      IsChecked="{Binding Settings.ImportGameExtras}"
+                      Content="{DynamicResource LOCHumbleImportGameExtras}"
+                      ToolTip="{DynamicResource LOCHumbleImportGameExtrasTooltip}" />
             <StackPanel IsEnabled="{Binding IsChecked, ElementName=HumbleImportGeneralLibrary}">
                 <CheckBox Margin="20,10,0,0" Name="HumbleThirdPartyImport"
                       IsChecked="{Binding Settings.IgnoreThirdPartyStoreGames}"
@@ -40,7 +44,7 @@
                       ToolTip="{DynamicResource LOCHumbleImportThirdPartyDrmFreeTooltip}"/>
             </StackPanel>
             <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
-                <Button Content="{DynamicResource LOCHumbleAuthenticateLabel}" HorizontalAlignment="Left"                         
+                <Button Content="{DynamicResource LOCHumbleAuthenticateLabel}" HorizontalAlignment="Left"
                         Command="{Binding LoginCommand}" Margin="0,5,5,5"/>
                 <TextBlock VerticalAlignment="Center" Margin="10,5,5,5">
                     <TextBlock.Tag>

--- a/source/Libraries/HumbleLibrary/HumbleLibrarySettingsView.xaml
+++ b/source/Libraries/HumbleLibrary/HumbleLibrarySettingsView.xaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:pcmd="clr-namespace:Playnite.Commands"
+             xmlns:pcon="clr-namespace:Playnite.Converters"
              xmlns:sys="clr-namespace:System;assembly=mscorlib"
              mc:Ignorable="d"
              d:DesignHeight="400" d:DesignWidth="600">
@@ -42,7 +43,8 @@
             <CheckBox Margin="0,10,0,0" Name="HumbleImportGameExtras"
                       IsChecked="{Binding Settings.ImportGameExtras}"
                       Content="{DynamicResource LOCImportGameExtras}"
-                      ToolTip="{DynamicResource LOCImportGameExtrasTooltip}" />
+                      ToolTip="{DynamicResource LOCImportGameExtrasTooltip}"
+                      Visibility="{Binding IsFirstRunUse, Converter={pcon:InvertedBooleanToVisibilityConverter}}"/>
             <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
                 <Button Content="{DynamicResource LOCHumbleAuthenticateLabel}" HorizontalAlignment="Left"
                         Command="{Binding LoginCommand}" Margin="0,5,5,5"/>

--- a/source/Libraries/HumbleLibrary/HumbleLibrarySettingsViewModel.cs
+++ b/source/Libraries/HumbleLibrary/HumbleLibrarySettingsViewModel.cs
@@ -16,6 +16,7 @@ namespace HumbleLibrary
         public bool IgnoreThirdPartyStoreGames { get; set; } = true;
         public bool ImportThirdPartyDrmFree { get; set; } = false;
         public bool ImportGeneralLibrary { get; set; } = true;
+        public bool ImportGameExtras { get; set; } = true;
         public bool ImportTroveGames { get; set; } = false;
         public bool LaunchViaHumbleApp { get; set; } = true;
     }

--- a/source/Libraries/HumbleLibrary/HumbleLibrarySettingsViewModel.cs
+++ b/source/Libraries/HumbleLibrary/HumbleLibrarySettingsViewModel.cs
@@ -16,7 +16,7 @@ namespace HumbleLibrary
         public bool IgnoreThirdPartyStoreGames { get; set; } = true;
         public bool ImportThirdPartyDrmFree { get; set; } = false;
         public bool ImportGeneralLibrary { get; set; } = true;
-        public bool ImportGameExtras { get; set; } = true;
+        public bool ImportGameExtras { get; set; } = false;
         public bool ImportTroveGames { get; set; } = false;
         public bool LaunchViaHumbleApp { get; set; } = true;
     }

--- a/source/Libraries/HumbleLibrary/Localization/en_US.xaml
+++ b/source/Libraries/HumbleLibrary/Localization/en_US.xaml
@@ -26,6 +26,8 @@
   <sys:String x:Key="LOCHumbleImportChoiceGamesTooltip">Import games available as part of Humble Choice subscription.</sys:String>
   <sys:String x:Key="LOCHumbleGeneralLibrary">Import Humble Library games</sys:String>
   <sys:String x:Key="LOCHumbleGeneralLibraryTooltip">Import standard Humble store purchases and bundle purchases.</sys:String>
+  <sys:String x:Key="LOCHumbleImportGameExtras">Import game extras</sys:String>
+  <sys:String x:Key="LOCHumbleImportGameExtrasTooltip">Import game extras (soundtracks, artwork, guides, ...) when importing games</sys:String>
   <sys:String x:Key="LOCHumbleIgnoreThirdPartyStoreGamesTooltip" xml:space="preserve">Enable to skip importing games that require third-party clients,
 including stores already managed in Playnite, to prevent duplicates.</sys:String>
   <sys:String x:Key="LOCHumbleImportThirdPartyDrmFree">Import if DRM free version is available</sys:String>

--- a/source/Libraries/HumbleLibrary/Localization/en_US.xaml
+++ b/source/Libraries/HumbleLibrary/Localization/en_US.xaml
@@ -20,14 +20,14 @@
   <sys:String x:Key="LOCHumbleAccountID">Account ID</sys:String>
   <sys:String x:Key="LOCHumbleGetAccountID">Get account ID</sys:String>
   <sys:String x:Key="LOCHumbleMetadataLanguageLabel">Metadata language:</sys:String>
+  <sys:String x:Key="LOCImportGameExtras">Also import non-game extras</sys:String>
+  <sys:String x:Key="LOCImportGameExtrasTooltip">Import things like soundtracks, artwork, guides as separate entries</sys:String>
   <!--Humble-->
   <sys:String x:Key="LOCHumbleIgnoreThirdPartyStoreGames">Ignore third party store games</sys:String>
   <sys:String x:Key="LOCHumbleImportChoiceGames">Import Humble Choice games</sys:String>
   <sys:String x:Key="LOCHumbleImportChoiceGamesTooltip">Import games available as part of Humble Choice subscription.</sys:String>
   <sys:String x:Key="LOCHumbleGeneralLibrary">Import Humble Library games</sys:String>
   <sys:String x:Key="LOCHumbleGeneralLibraryTooltip">Import standard Humble store purchases and bundle purchases.</sys:String>
-  <sys:String x:Key="LOCHumbleImportGameExtras">Also import game extras</sys:String>
-  <sys:String x:Key="LOCHumbleImportGameExtrasTooltip">Import game extras (soundtracks, artwork, guides, ...) when importing games</sys:String>
   <sys:String x:Key="LOCHumbleIgnoreThirdPartyStoreGamesTooltip" xml:space="preserve">Enable to skip importing games that require third-party clients,
 including stores already managed in Playnite, to prevent duplicates.</sys:String>
   <sys:String x:Key="LOCHumbleImportThirdPartyDrmFree">Import if DRM free version is available</sys:String>

--- a/source/Libraries/HumbleLibrary/Localization/en_US.xaml
+++ b/source/Libraries/HumbleLibrary/Localization/en_US.xaml
@@ -26,7 +26,7 @@
   <sys:String x:Key="LOCHumbleImportChoiceGamesTooltip">Import games available as part of Humble Choice subscription.</sys:String>
   <sys:String x:Key="LOCHumbleGeneralLibrary">Import Humble Library games</sys:String>
   <sys:String x:Key="LOCHumbleGeneralLibraryTooltip">Import standard Humble store purchases and bundle purchases.</sys:String>
-  <sys:String x:Key="LOCHumbleImportGameExtras">Import game extras</sys:String>
+  <sys:String x:Key="LOCHumbleImportGameExtras">Also import game extras</sys:String>
   <sys:String x:Key="LOCHumbleImportGameExtrasTooltip">Import game extras (soundtracks, artwork, guides, ...) when importing games</sys:String>
   <sys:String x:Key="LOCHumbleIgnoreThirdPartyStoreGamesTooltip" xml:space="preserve">Enable to skip importing games that require third-party clients,
 including stores already managed in Playnite, to prevent duplicates.</sys:String>

--- a/source/Libraries/HumbleLibrary/Localization/en_US.xaml
+++ b/source/Libraries/HumbleLibrary/Localization/en_US.xaml
@@ -20,8 +20,8 @@
   <sys:String x:Key="LOCHumbleAccountID">Account ID</sys:String>
   <sys:String x:Key="LOCHumbleGetAccountID">Get account ID</sys:String>
   <sys:String x:Key="LOCHumbleMetadataLanguageLabel">Metadata language:</sys:String>
-  <sys:String x:Key="LOCImportGameExtras">Also import non-game extras</sys:String>
-  <sys:String x:Key="LOCImportGameExtrasTooltip">Import things like soundtracks, artwork, guides as separate entries</sys:String>
+  <sys:String x:Key="LOCHumbleImportGameExtras">Also import non-game extras</sys:String>
+  <sys:String x:Key="LOCHumbleImportGameExtrasTooltip">Import things like soundtracks, artwork, guides as separate entries</sys:String>
   <!--Humble-->
   <sys:String x:Key="LOCHumbleIgnoreThirdPartyStoreGames">Ignore third party store games</sys:String>
   <sys:String x:Key="LOCHumbleImportChoiceGames">Import Humble Choice games</sys:String>

--- a/source/Libraries/HumbleLibrary/LocalizationKeys.cs
+++ b/source/Libraries/HumbleLibrary/LocalizationKeys.cs
@@ -110,7 +110,7 @@ namespace System
         /// </summary>
         public const string HumbleGeneralLibraryTooltip = "LOCHumbleGeneralLibraryTooltip";
         /// <summary>
-        /// Import game extras
+        /// Also import game extras
         /// </summary>
         public const string HumbleImportGameExtras = "LOCHumbleImportGameExtras";
         /// <summary>

--- a/source/Libraries/HumbleLibrary/LocalizationKeys.cs
+++ b/source/Libraries/HumbleLibrary/LocalizationKeys.cs
@@ -110,14 +110,6 @@ namespace System
         /// </summary>
         public const string HumbleGeneralLibraryTooltip = "LOCHumbleGeneralLibraryTooltip";
         /// <summary>
-        /// Also import game extras
-        /// </summary>
-        public const string HumbleImportGameExtras = "LOCHumbleImportGameExtras";
-        /// <summary>
-        /// Import game extras (soundtracks, artwork, guides, ...) when importing games
-        /// </summary>
-        public const string HumbleImportGameExtrasTooltip = "LOCHumbleImportGameExtrasTooltip";
-        /// <summary>
         /// Enable to skip importing games that require third-party clients,
         /// </summary>
         public const string HumbleIgnoreThirdPartyStoreGamesTooltip = "LOCHumbleIgnoreThirdPartyStoreGamesTooltip";

--- a/source/Libraries/HumbleLibrary/LocalizationKeys.cs
+++ b/source/Libraries/HumbleLibrary/LocalizationKeys.cs
@@ -1,6 +1,6 @@
 ///
 /// DO NOT MODIFY! Automatically generated via UpdateLocExtFiles.ps1 script.
-///
+/// 
 namespace System
 {
     public static class LOC
@@ -89,6 +89,14 @@ namespace System
         /// Metadata language:
         /// </summary>
         public const string HumbleMetadataLanguageLabel = "LOCHumbleMetadataLanguageLabel";
+        /// <summary>
+        /// Also import non-game extras
+        /// </summary>
+        public const string HumbleImportGameExtras = "LOCHumbleImportGameExtras";
+        /// <summary>
+        /// Import things like soundtracks, artwork, guides as separate entries
+        /// </summary>
+        public const string HumbleImportGameExtrasTooltip = "LOCHumbleImportGameExtrasTooltip";
         /// <summary>
         /// Ignore third party store games
         /// </summary>

--- a/source/Libraries/HumbleLibrary/LocalizationKeys.cs
+++ b/source/Libraries/HumbleLibrary/LocalizationKeys.cs
@@ -1,6 +1,6 @@
 ///
 /// DO NOT MODIFY! Automatically generated via UpdateLocExtFiles.ps1 script.
-/// 
+///
 namespace System
 {
     public static class LOC
@@ -109,6 +109,14 @@ namespace System
         /// Import standard Humble store purchases and bundle purchases.
         /// </summary>
         public const string HumbleGeneralLibraryTooltip = "LOCHumbleGeneralLibraryTooltip";
+        /// <summary>
+        /// Import game extras
+        /// </summary>
+        public const string HumbleImportGameExtras = "LOCHumbleImportGameExtras";
+        /// <summary>
+        /// Import game extras (soundtracks, artwork, guides, ...) when importing games
+        /// </summary>
+        public const string HumbleImportGameExtrasTooltip = "LOCHumbleImportGameExtrasTooltip";
         /// <summary>
         /// Enable to skip importing games that require third-party clients,
         /// </summary>

--- a/source/Libraries/HumbleLibrary/Models/Extra.cs
+++ b/source/Libraries/HumbleLibrary/Models/Extra.cs
@@ -1,0 +1,16 @@
+namespace HumbleLibrary.Models
+{
+    public class Extra
+    {
+        // TODO gameKeys are private. should this json file be encrypted?
+        public string GameKey { get; set; }
+
+        public string Sha1 { get; set; }
+
+        /// <summary>
+        /// For asm.js humble games - they have unique url (with gameKey) that does not require authentication and never changes
+        /// </summary>
+        public string PermanentUrl { get; set; }
+
+    }
+}

--- a/source/Libraries/HumbleLibrary/Models/Extra.cs
+++ b/source/Libraries/HumbleLibrary/Models/Extra.cs
@@ -2,9 +2,14 @@ namespace HumbleLibrary.Models
 {
     public class Extra
     {
-        // TODO gameKeys are private. should this json file be encrypted?
+        /// <summary>
+        /// This is sensitive info, that's why json file with extras is encrypted
+        /// </summary>
         public string GameKey { get; set; }
 
+        /// <summary>
+        /// Helps identify given "extra" in a list of "downloads" returned from api
+        /// </summary>
         public string Sha1 { get; set; }
 
         /// <summary>

--- a/source/Libraries/HumbleLibrary/Models/Extra.cs
+++ b/source/Libraries/HumbleLibrary/Models/Extra.cs
@@ -8,9 +8,9 @@ namespace HumbleLibrary.Models
         public string GameKey { get; set; }
 
         /// <summary>
-        /// Helps identify given "extra" in a list of "downloads" returned from api
+        /// Helps identify given "extra" in a list of "downloads" returned from api. There is also sha1, but it is missing in some downloads
         /// </summary>
-        public string Sha1 { get; set; }
+        public string Md5 { get; set; }
 
         /// <summary>
         /// For asm.js humble games - they have unique url (with gameKey) that does not require authentication and never changes

--- a/source/Libraries/HumbleLibrary/packages.config
+++ b/source/Libraries/HumbleLibrary/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AngleSharp" version="0.9.9" targetFramework="net462" />
-  <package id="PlayniteSDK" version="6.2.2" targetFramework="net462" />
+  <package id="PlayniteSDK" version="6.14.0" targetFramework="net462" />
 </packages>

--- a/source/Libraries/ItchioLibrary/Localization/en_US.xaml
+++ b/source/Libraries/ItchioLibrary/Localization/en_US.xaml
@@ -20,6 +20,8 @@
   <sys:String x:Key="LOCitchioAccountID">Account ID</sys:String>
   <sys:String x:Key="LOCitchioGetAccountID">Get account ID</sys:String>
   <sys:String x:Key="LOCitchioMetadataLanguageLabel">Metadata language:</sys:String>
+  <sys:String x:Key="LOCitchioImportGameExtras">Also import non-game extras</sys:String>
+  <sys:String x:Key="LOCitchioImportGameExtrasTooltip">Import things like soundtracks, artwork, guides as separate entries</sys:String>
   <!--itch.io-->
   <sys:String x:Key="LOCItchioSignInNotif">itch.io will be launched. Please sign in and then close this message.</sys:String>
   <sys:String x:Key="LOCItchioSignInWaitMessage">Waiting for user to sign in, please close this when you're done…</sys:String>

--- a/source/Libraries/ItchioLibrary/LocalizationKeys.cs
+++ b/source/Libraries/ItchioLibrary/LocalizationKeys.cs
@@ -90,6 +90,14 @@ namespace System
         /// </summary>
         public const string itchioMetadataLanguageLabel = "LOCitchioMetadataLanguageLabel";
         /// <summary>
+        /// Also import non-game extras
+        /// </summary>
+        public const string itchioImportGameExtras = "LOCitchioImportGameExtras";
+        /// <summary>
+        /// Import things like soundtracks, artwork, guides as separate entries
+        /// </summary>
+        public const string itchioImportGameExtrasTooltip = "LOCitchioImportGameExtrasTooltip";
+        /// <summary>
         /// itch.io will be launched. Please sign in and then close this message.
         /// </summary>
         public const string ItchioSignInNotif = "LOCItchioSignInNotif";

--- a/source/Libraries/RockstarLibrary/Localization/en_US.xaml
+++ b/source/Libraries/RockstarLibrary/Localization/en_US.xaml
@@ -20,6 +20,8 @@
   <sys:String x:Key="LOCRockstarAccountID">Account ID</sys:String>
   <sys:String x:Key="LOCRockstarGetAccountID">Get account ID</sys:String>
   <sys:String x:Key="LOCRockstarMetadataLanguageLabel">Metadata language:</sys:String>
+  <sys:String x:Key="LOCRockstarImportGameExtras">Also import non-game extras</sys:String>
+  <sys:String x:Key="LOCRockstarImportGameExtrasTooltip">Import things like soundtracks, artwork, guides as separate entries</sys:String>
   <!--Rockstar-->
   <sys:String x:Key="LOCRockstarSettingsNotice" xml:space="preserve">Rockstar plugin currently only imports installed games. There is no way to link an account to import all games.</sys:String>
 </ResourceDictionary>

--- a/source/Libraries/RockstarLibrary/LocalizationKeys.cs
+++ b/source/Libraries/RockstarLibrary/LocalizationKeys.cs
@@ -90,6 +90,14 @@ namespace System
         /// </summary>
         public const string RockstarMetadataLanguageLabel = "LOCRockstarMetadataLanguageLabel";
         /// <summary>
+        /// Also import non-game extras
+        /// </summary>
+        public const string RockstarImportGameExtras = "LOCRockstarImportGameExtras";
+        /// <summary>
+        /// Import things like soundtracks, artwork, guides as separate entries
+        /// </summary>
+        public const string RockstarImportGameExtrasTooltip = "LOCRockstarImportGameExtrasTooltip";
+        /// <summary>
         /// Rockstar plugin currently only imports installed games. There is no way to link an account to import all games.
         /// </summary>
         public const string RockstarSettingsNotice = "LOCRockstarSettingsNotice";

--- a/source/Libraries/SteamLibrary/Localization/en_US.xaml
+++ b/source/Libraries/SteamLibrary/Localization/en_US.xaml
@@ -20,6 +20,8 @@
   <sys:String x:Key="LOCSteamAccountID">Account ID</sys:String>
   <sys:String x:Key="LOCSteamGetAccountID">Get account ID</sys:String>
   <sys:String x:Key="LOCSteamMetadataLanguageLabel">Metadata language:</sys:String>
+  <sys:String x:Key="LOCSteamImportGameExtras">Also import non-game extras</sys:String>
+  <sys:String x:Key="LOCSteamImportGameExtrasTooltip">Import things like soundtracks, artwork, guides as separate entries</sys:String>
   <!--Steam-->
   <sys:String x:Key="LOCSettingsWhatsSteamName">What's my account name?</sys:String>
   <sys:String x:Key="LOCSteamCustomUrlName">Account URL Name</sys:String>

--- a/source/Libraries/SteamLibrary/LocalizationKeys.cs
+++ b/source/Libraries/SteamLibrary/LocalizationKeys.cs
@@ -90,6 +90,14 @@ namespace System
         /// </summary>
         public const string SteamMetadataLanguageLabel = "LOCSteamMetadataLanguageLabel";
         /// <summary>
+        /// Also import non-game extras
+        /// </summary>
+        public const string SteamImportGameExtras = "LOCSteamImportGameExtras";
+        /// <summary>
+        /// Import things like soundtracks, artwork, guides as separate entries
+        /// </summary>
+        public const string SteamImportGameExtrasTooltip = "LOCSteamImportGameExtrasTooltip";
+        /// <summary>
         /// What's my account name?
         /// </summary>
         public const string SettingsWhatsSteamName = "LOCSettingsWhatsSteamName";

--- a/source/Libraries/UplayLibrary/Localization/en_US.xaml
+++ b/source/Libraries/UplayLibrary/Localization/en_US.xaml
@@ -20,6 +20,8 @@
   <sys:String x:Key="LOCUbisoftAccountID">Account ID</sys:String>
   <sys:String x:Key="LOCUbisoftGetAccountID">Get account ID</sys:String>
   <sys:String x:Key="LOCUbisoftMetadataLanguageLabel">Metadata language:</sys:String>
+  <sys:String x:Key="LOCUbisoftImportGameExtras">Also import non-game extras</sys:String>
+  <sys:String x:Key="LOCUbisoftImportGameExtrasTooltip">Import things like soundtracks, artwork, guides as separate entries</sys:String>
   <!--Ubisoft-->
   <sys:String x:Key="LOCUbisoftSettingsNotice" xml:space="preserve">Ubisoft plugins doesn't require any authentication, it takes library information from Ubisoft Connect client's user data files.
 

--- a/source/Libraries/UplayLibrary/LocalizationKeys.cs
+++ b/source/Libraries/UplayLibrary/LocalizationKeys.cs
@@ -90,6 +90,14 @@ namespace System
         /// </summary>
         public const string UbisoftMetadataLanguageLabel = "LOCUbisoftMetadataLanguageLabel";
         /// <summary>
+        /// Also import non-game extras
+        /// </summary>
+        public const string UbisoftImportGameExtras = "LOCUbisoftImportGameExtras";
+        /// <summary>
+        /// Import things like soundtracks, artwork, guides as separate entries
+        /// </summary>
+        public const string UbisoftImportGameExtrasTooltip = "LOCUbisoftImportGameExtrasTooltip";
+        /// <summary>
         /// Ubisoft plugins doesn't require any authentication, it takes library information from Ubisoft Connect client's user data files.
         /// </summary>
         public const string UbisoftSettingsNotice = "LOCUbisoftSettingsNotice";

--- a/source/Libraries/XboxLibrary/Localization/en_US.xaml
+++ b/source/Libraries/XboxLibrary/Localization/en_US.xaml
@@ -20,6 +20,8 @@
   <sys:String x:Key="LOCXboxAccountID">Account ID</sys:String>
   <sys:String x:Key="LOCXboxGetAccountID">Get account ID</sys:String>
   <sys:String x:Key="LOCXboxMetadataLanguageLabel">Metadata language:</sys:String>
+  <sys:String x:Key="LOCXboxImportGameExtras">Also import non-game extras</sys:String>
+  <sys:String x:Key="LOCXboxImportGameExtrasTooltip">Import things like soundtracks, artwork, guides as separate entries</sys:String>
   <!--Xbox-->
   <sys:String x:Key="LOCXboxXboxAppClientPriorityLaunch">Start Xbox Pass app instead of Microsoft Store when opening client</sys:String>
   <sys:String x:Key="LOCXboxImportConsoleGames">Import Xbox console games</sys:String>

--- a/source/Libraries/XboxLibrary/LocalizationKeys.cs
+++ b/source/Libraries/XboxLibrary/LocalizationKeys.cs
@@ -90,6 +90,14 @@ namespace System
         /// </summary>
         public const string XboxMetadataLanguageLabel = "LOCXboxMetadataLanguageLabel";
         /// <summary>
+        /// Also import non-game extras
+        /// </summary>
+        public const string XboxImportGameExtras = "LOCXboxImportGameExtras";
+        /// <summary>
+        /// Import things like soundtracks, artwork, guides as separate entries
+        /// </summary>
+        public const string XboxImportGameExtrasTooltip = "LOCXboxImportGameExtrasTooltip";
+        /// <summary>
         /// Start Xbox Pass app instead of Microsoft Store when opening client
         /// </summary>
         public const string XboxXboxAppClientPriorityLaunch = "LOCXboxXboxAppClientPriorityLaunch";

--- a/source/Localization/en_US.xaml
+++ b/source/Localization/en_US.xaml
@@ -120,7 +120,7 @@ If disabled, the game page will be opened to manually start the install process.
     <sys:String x:Key="LOCHumbleImportChoiceGamesTooltip">Import games available as part of Humble Choice subscription.</sys:String>
     <sys:String x:Key="LOCHumbleGeneralLibrary">Import Humble Library games</sys:String>
     <sys:String x:Key="LOCHumbleGeneralLibraryTooltip">Import standard Humble store purchases and bundle purchases.</sys:String>
-    <sys:String x:Key="LOCHumbleImportGameExtras">Import game extras</sys:String>
+    <sys:String x:Key="LOCHumbleImportGameExtras">Also import game extras</sys:String>
     <sys:String x:Key="LOCHumbleImportGameExtrasTooltip">Import game extras (soundtracks, artwork, guides, ...) when importing games</sys:String>
     <sys:String x:Key="LOCHumbleIgnoreThirdPartyStoreGamesTooltip" xml:space="preserve">Enable to skip importing games that require third-party clients,
 including stores already managed in Playnite, to prevent duplicates.</sys:String>

--- a/source/Localization/en_US.xaml
+++ b/source/Localization/en_US.xaml
@@ -46,6 +46,7 @@ Note that the Account Name option only works for accounts whose game libraries h
     <sys:String x:Key="LOCGOGSettingsUseAutomaticGameInstallsTooltip" xml:space="preserve">If enabled, the install process will be automatically started without needing user interaction to the configured default install location.
 If disabled, the game page will be opened to manually start the install process.</sys:String>
     <sys:String x:Key="LOCGOGSettingsUseVerticalCovers">Use vertical covers</sys:String>
+    <sys:String x:Key="LOCGOGSettingsImportGameExtras">Also import game extras</sys:String>
     <!--Steam-->
     <sys:String x:Key="LOCSettingsWhatsSteamName">What's my account name?</sys:String>
     <sys:String x:Key="LOCSteamCustomUrlName">Account URL Name</sys:String>
@@ -119,6 +120,8 @@ If disabled, the game page will be opened to manually start the install process.
     <sys:String x:Key="LOCHumbleImportChoiceGamesTooltip">Import games available as part of Humble Choice subscription.</sys:String>
     <sys:String x:Key="LOCHumbleGeneralLibrary">Import Humble Library games</sys:String>
     <sys:String x:Key="LOCHumbleGeneralLibraryTooltip">Import standard Humble store purchases and bundle purchases.</sys:String>
+    <sys:String x:Key="LOCHumbleImportGameExtras">Import game extras</sys:String>
+    <sys:String x:Key="LOCHumbleImportGameExtrasTooltip">Import game extras (soundtracks, artwork, guides, ...) when importing games</sys:String>
     <sys:String x:Key="LOCHumbleIgnoreThirdPartyStoreGamesTooltip" xml:space="preserve">Enable to skip importing games that require third-party clients,
 including stores already managed in Playnite, to prevent duplicates.</sys:String>
     <sys:String x:Key="LOCHumbleImportThirdPartyDrmFree">Import if DRM free version is available</sys:String>

--- a/source/Localization/en_US.xaml
+++ b/source/Localization/en_US.xaml
@@ -20,6 +20,8 @@
     <sys:String x:Key="LOCAccountID">Account ID</sys:String>
     <sys:String x:Key="LOCGetAccountID">Get account ID</sys:String>
     <sys:String x:Key="LOCMetadataLanguageLabel">Metadata language:</sys:String>
+    <sys:String x:Key="LOCImportGameExtras">Also import non-game extras</sys:String>
+    <sys:String x:Key="LOCImportGameExtrasTooltip">Import things like soundtracks, artwork, guides as separate entries</sys:String>
     <!--itch.io-->
     <sys:String x:Key="LOCItchioSignInNotif">itch.io will be launched. Please sign in and then close this message.</sys:String>
     <sys:String x:Key="LOCItchioSignInWaitMessage">Waiting for user to sign in, please close this when you're done…</sys:String>
@@ -46,7 +48,6 @@ Note that the Account Name option only works for accounts whose game libraries h
     <sys:String x:Key="LOCGOGSettingsUseAutomaticGameInstallsTooltip" xml:space="preserve">If enabled, the install process will be automatically started without needing user interaction to the configured default install location.
 If disabled, the game page will be opened to manually start the install process.</sys:String>
     <sys:String x:Key="LOCGOGSettingsUseVerticalCovers">Use vertical covers</sys:String>
-    <sys:String x:Key="LOCGOGSettingsImportGameExtras">Also import game extras</sys:String>
     <!--Steam-->
     <sys:String x:Key="LOCSettingsWhatsSteamName">What's my account name?</sys:String>
     <sys:String x:Key="LOCSteamCustomUrlName">Account URL Name</sys:String>
@@ -120,8 +121,6 @@ If disabled, the game page will be opened to manually start the install process.
     <sys:String x:Key="LOCHumbleImportChoiceGamesTooltip">Import games available as part of Humble Choice subscription.</sys:String>
     <sys:String x:Key="LOCHumbleGeneralLibrary">Import Humble Library games</sys:String>
     <sys:String x:Key="LOCHumbleGeneralLibraryTooltip">Import standard Humble store purchases and bundle purchases.</sys:String>
-    <sys:String x:Key="LOCHumbleImportGameExtras">Also import game extras</sys:String>
-    <sys:String x:Key="LOCHumbleImportGameExtrasTooltip">Import game extras (soundtracks, artwork, guides, ...) when importing games</sys:String>
     <sys:String x:Key="LOCHumbleIgnoreThirdPartyStoreGamesTooltip" xml:space="preserve">Enable to skip importing games that require third-party clients,
 including stores already managed in Playnite, to prevent duplicates.</sys:String>
     <sys:String x:Key="LOCHumbleImportThirdPartyDrmFree">Import if DRM free version is available</sys:String>

--- a/source/Metadata/IGDBMetadata/Localization/en_US.xaml
+++ b/source/Metadata/IGDBMetadata/Localization/en_US.xaml
@@ -20,6 +20,8 @@
   <sys:String x:Key="LOCIGDBAccountID">Account ID</sys:String>
   <sys:String x:Key="LOCIGDBGetAccountID">Get account ID</sys:String>
   <sys:String x:Key="LOCIGDBMetadataLanguageLabel">Metadata language:</sys:String>
+  <sys:String x:Key="LOCIGDBImportGameExtras">Also import non-game extras</sys:String>
+  <sys:String x:Key="LOCIGDBImportGameExtrasTooltip">Import things like soundtracks, artwork, guides as separate entries</sys:String>
   <!--IGDB-->
   <sys:String x:Key="LOCIgdbUseScreenshotIfNecessary">Use screenshots if artwork is not available</sys:String>
   <sys:String x:Key="LOCIgdbMultipleArtworkOptionsTitle">If multiple images are available then use:</sys:String>

--- a/source/Metadata/IGDBMetadata/LocalizationKeys.cs
+++ b/source/Metadata/IGDBMetadata/LocalizationKeys.cs
@@ -90,6 +90,14 @@ namespace System
         /// </summary>
         public const string IGDBMetadataLanguageLabel = "LOCIGDBMetadataLanguageLabel";
         /// <summary>
+        /// Also import non-game extras
+        /// </summary>
+        public const string IGDBImportGameExtras = "LOCIGDBImportGameExtras";
+        /// <summary>
+        /// Import things like soundtracks, artwork, guides as separate entries
+        /// </summary>
+        public const string IGDBImportGameExtrasTooltip = "LOCIGDBImportGameExtrasTooltip";
+        /// <summary>
         /// Use screenshots if artwork is not available
         /// </summary>
         public const string IgdbUseScreenshotIfNecessary = "LOCIgdbUseScreenshotIfNecessary";

--- a/source/Metadata/UniversalSteamMetadata/Localization/en_US.xaml
+++ b/source/Metadata/UniversalSteamMetadata/Localization/en_US.xaml
@@ -20,6 +20,8 @@
   <sys:String x:Key="LOCUniversalSteamMetadataAccountID">Account ID</sys:String>
   <sys:String x:Key="LOCUniversalSteamMetadataGetAccountID">Get account ID</sys:String>
   <sys:String x:Key="LOCUniversalSteamMetadataMetadataLanguageLabel">Metadata language:</sys:String>
+  <sys:String x:Key="LOCUniversalSteamMetadataImportGameExtras">Also import non-game extras</sys:String>
+  <sys:String x:Key="LOCUniversalSteamMetadataImportGameExtrasTooltip">Import things like soundtracks, artwork, guides as separate entries</sys:String>
   <!--Steam-->
   <sys:String x:Key="LOCSettingsWhatsSteamName">What's my account name?</sys:String>
   <sys:String x:Key="LOCSteamCustomUrlName">Account URL Name</sys:String>

--- a/source/Metadata/UniversalSteamMetadata/LocalizationKeys.cs
+++ b/source/Metadata/UniversalSteamMetadata/LocalizationKeys.cs
@@ -90,6 +90,14 @@ namespace System
         /// </summary>
         public const string UniversalSteamMetadataMetadataLanguageLabel = "LOCUniversalSteamMetadataMetadataLanguageLabel";
         /// <summary>
+        /// Also import non-game extras
+        /// </summary>
+        public const string UniversalSteamMetadataImportGameExtras = "LOCUniversalSteamMetadataImportGameExtras";
+        /// <summary>
+        /// Import things like soundtracks, artwork, guides as separate entries
+        /// </summary>
+        public const string UniversalSteamMetadataImportGameExtrasTooltip = "LOCUniversalSteamMetadataImportGameExtrasTooltip";
+        /// <summary>
         /// What's my account name?
         /// </summary>
         public const string SettingsWhatsSteamName = "LOCSettingsWhatsSteamName";


### PR DESCRIPTION
Optional feature for GOG and Humble plugins to import non-game extra content like soundtracks, artbooks, ...

* Implemented as additional checkbox in both plugins settings
* Imported items have `extras` category
* They are just direct downloads, not something "installable" and "launchable". Every item has a link for download. Install button opens browser with that link.
* Not sure if i should update all localization resources? Please advice
* GOG import takes more time because there's a HTTP request for every game

if this gets merged, i'd like to do something for Steam too

build of both plugins to try: [build.zip](https://github.com/user-attachments/files/23591010/build.zip)

<img width="1004" height="551" alt="image" src="https://github.com/user-attachments/assets/bc10e93b-c320-4b41-9b1c-6bd4b28bbe0c" />

