### PR TITLE
Steam: fixed error for family group of 1

### DIFF
--- a/source/Libraries/SteamLibrary/Services/FamilyGroupsService.cs
+++ b/source/Libraries/SteamLibrary/Services/FamilyGroupsService.cs
@@ -17,6 +17,10 @@ namespace SteamLibrary.Services
                 return Enumerable.Empty<GameMetadata>();
 
             var sharedLibrary = GetSharedLibraryApps(settings, userToken, familyGroup.family_groupid);
+
+            if (sharedLibrary.apps == null) //user is most likely in a family group without any other members
+                return Enumerable.Empty<GameMetadata>();
+
             userIds = sharedLibrary.apps.SelectMany(a => a.owner_steamids).ToHashSet();
 
             return sharedLibrary.apps.Select(ToGame);


### PR DESCRIPTION
Got reporting user to submit their GetSharedLibraryApps response, which was (ID redacted): `{"response":{"owner_steamid":"1234"}}`. He's in a Steam Family group without anyone else in it.
Sent a build of this, and he verified it's fixed.