### PR TITLE
Steam: don't create sources without games to assign them to

### DIFF
--- a/source/Libraries/SteamLibrary/Services/SteamServiceAggregator.cs
+++ b/source/Libraries/SteamLibrary/Services/SteamServiceAggregator.cs
@@ -238,12 +238,15 @@ namespace SteamLibrary.Services
                     bool update = false;
 
                     var oldSource = existingGame.Source;
-                    var newSource = GetOrCreateSource(((MetadataNameProperty)newGame.Source).Name);
-
-                    if (SourceNames.AllKnown.Contains(oldSource?.Name) && oldSource?.Id != newSource.Id)
+                    if (SourceNames.AllKnown.Contains(oldSource?.Name, StringComparer.InvariantCultureIgnoreCase))
                     {
-                        existingGame.SourceId = newSource.Id;
-                        update = true;
+                        var newSource = GetOrCreateSource(((MetadataNameProperty)newGame.Source).Name);
+
+                        if (oldSource?.Id != newSource.Id)
+                        {
+                            existingGame.SourceId = newSource.Id;
+                            update = true;
+                        }
                     }
 
                     if (!(existingGame.InstallSize > 0) && newGame.InstallSize > 0)


### PR DESCRIPTION
Sorry to keep updating the source update handling. User reported that the "Steam" source would always be created on import, even if no new games were added, and all existing Steam library games had a non-standard source. This should fix that.