### PR TITLE
feat: steam import rework

### DIFF
--- a/source/Libraries/SteamLibrary/ModInfo.cs
+++ b/source/Libraries/SteamLibrary/ModInfo.cs
@@ -3,12 +3,15 @@ using SteamKit2;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using SteamLibrary.Models;
+using SteamLibrary.Services;
 
 namespace SteamLibrary
 {
-    internal class ModInfo
+    internal class ModInfo : ISteamApp
     {
         public enum ModType
         {
@@ -17,7 +20,7 @@ namespace SteamLibrary
         }
 
         public string Name { get; private set; }
-        public GameID GameId { get; private set; }
+        public GameID Id { get; private set; }
         public string InstallFolder { get; private set; }
         public List<string> Categories { get; private set; }
         public string Developer { get; private set; }
@@ -49,7 +52,7 @@ namespace SteamLibrary
             InstallFolder = installFolder;
             Name = "Unknown Mod";
             Links = new List<Link>();
-            GameId = new GameID();
+            Id = new GameID();
             Developer = "Unknown";
             Categories = new List<string>();
         }
@@ -106,7 +109,7 @@ namespace SteamLibrary
             ModInfo modInfo = new ModInfo(modType, path);
             if (modType == ModType.HL)
             {
-                modInfo.GameId.AppID = halfLife;
+                modInfo.Id.AppID = halfLife;
                 PopulateModInfoFromLibList(ref modInfo, gameInfoPath);
             }
             else
@@ -114,8 +117,8 @@ namespace SteamLibrary
                 PopulateModInfoFromGameInfo(ref modInfo, gameInfoPath);
             }
 
-            modInfo.GameId.AppType = GameID.GameType.GameMod;
-            modInfo.GameId.ModID = GetModFolderCRC(dirInfo.Name);
+            modInfo.Id.AppType = GameID.GameType.GameMod;
+            modInfo.Id.ModID = GetModFolderCRC(dirInfo.Name);
 
             return modInfo;
         }
@@ -141,7 +144,7 @@ namespace SteamLibrary
             var gameInfo = new KeyValue();
             gameInfo.ReadFileAsText(path);
 
-            modInfo.GameId.AppID = gameInfo["FileSystem"]["SteamAppId"].AsUnsignedInteger();
+            modInfo.Id.AppID = gameInfo["FileSystem"]["SteamAppId"].AsUnsignedInteger();
             modInfo.Name = gameInfo["game"].Value;
 
             if (gameInfo["developer"] != KeyValue.Invalid)
@@ -279,5 +282,31 @@ namespace SteamLibrary
 
             return null;
         }
+
+        public GameMetadata ToGame()
+        {
+            var game = new GameMetadata
+            {
+                GameId = Id,
+                Name = Name.RemoveTrademarks().Trim(),
+                InstallDirectory = InstallFolder,
+                IsInstalled = true,
+                Developers = new HashSet<MetadataProperty> { new MetadataNameProperty(Developer) },
+                Links = Links,
+                Tags = Categories?.Select(a => new MetadataNameProperty(a)).Cast<MetadataProperty>().ToHashSet(),
+                Platforms = new HashSet<MetadataProperty> { new MetadataSpecProperty("pc_windows") },
+                Source = SourceNames.GetSource(IsOwned, BackendAppInfo?.Type),
+            };
+
+            if (!IconPath.IsNullOrEmpty() && File.Exists(IconPath))
+            {
+                game.Icon = new MetadataFile(IconPath);
+            }
+
+            return game;
+        }
+
+        public bool IsOwned => true;
+        public BackendAppInfo BackendAppInfo { get; set; }
     }
 }

--- a/source/Libraries/SteamLibrary/Models/ApiResponseModels.cs
+++ b/source/Libraries/SteamLibrary/Models/ApiResponseModels.cs
@@ -1,4 +1,9 @@
+using System;
 using System.Collections.Generic;
+using Playnite.SDK.Models;
+using SteamKit2;
+using SteamLibrary.Services;
+using SteamLibrary.Services.Base;
 
 namespace SteamLibrary.Models
 {
@@ -19,7 +24,7 @@ namespace SteamLibrary.Models
         public string owner_steamid { get; set; }
     }
 
-    public class FamilySharedApp
+    public class FamilySharedApp : ISteamApp
     {
         public int appid { get; set; }
         public string[] owner_steamids { get; set; }
@@ -36,6 +41,48 @@ namespace SteamLibrary.Models
         public uint app_type { get; set; }
         public uint[] content_descriptors { get; set; }
         public string sort_as { get; set; }
+
+        public string NiceAppType =>
+            app_type switch
+            {
+                1 => "game",
+                2 => "application",
+                4 => "tool",
+                8 => "demo",
+                8192 => "soundtrack",
+                _ => $"{app_type}"
+            };
+
+        public string NiceExcludeReason =>
+            exclude_reason switch
+            {
+                0 => "none",
+                1 => "ineligible",
+                3 => "free",
+                6 => "type_not_shared", // guessed by looking at data
+                _ => $"{exclude_reason}"
+            };
+
+        // we probably don't want free apps coming from family members (they do exist)
+        public bool IsImportable => (NiceExcludeReason == "none" || NiceExcludeReason == "free")
+                                    && (NiceAppType == "game" || NiceAppType == "demo" || NiceAppType == "tool");
+
+        public GameMetadata ToGame()
+        {
+            return new GameMetadata
+            {
+                GameId = Id,
+                Name = name.RemoveTrademarks().Trim(),
+                LastActivity = SteamApiServiceBase.GetLastPlayedDateTime(rt_last_played),
+                Playtime = rt_playtime * 60,
+                Platforms = new HashSet<MetadataProperty> { new MetadataSpecProperty("pc_windows") },
+                Source = SourceNames.GetSource(IsOwned, BackendAppInfo?.Type),
+            };
+        }
+
+        public GameID Id => (uint)appid;
+        public bool IsOwned { get; set; }
+        public BackendAppInfo BackendAppInfo { get; set; }
     }
 
     public class GetClientAppListResponse
@@ -44,7 +91,7 @@ namespace SteamLibrary.Models
         public SteamClientApp[] apps { get; set; }
     }
 
-    public class SteamClientApp
+    public class SteamClientApp : ISteamApp
     {
         public ulong appid { get; set; }
         public string app { get; set; }
@@ -53,6 +100,31 @@ namespace SteamLibrary.Models
         public string bytes_required { get; set; }
         public bool running { get; set; }
         public bool installed { get; set; }
+
+        public GameMetadata ToGame()
+        {
+            return new GameMetadata
+            {
+                GameId = Id,
+                Name = app.RemoveTrademarks().Trim(),
+                InstallSize = GetInstallSize(),
+                Platforms = new HashSet<MetadataProperty> { new MetadataSpecProperty("pc_windows") },
+                Source = SourceNames.GetSource(IsOwned, BackendAppInfo?.Type),
+            };
+        }
+
+        public GameID Id => appid;
+        public bool IsOwned { get; set; } = true;
+        public BackendAppInfo BackendAppInfo { get; set; }
+
+
+        private ulong? GetInstallSize()
+        {
+            if (ulong.TryParse(bytes_required, out ulong size))
+                return size;
+
+            return null;
+        }
     }
 
     public class GetOwnedGamesResponse
@@ -61,11 +133,111 @@ namespace SteamLibrary.Models
         public List<OwnedGame> games { get; set; }
     }
 
-    public class OwnedGame
+    public class OwnedGame : ISteamApp
     {
         public int appid { get; set; }
         public string name { get; set; }
         public uint playtime_forever { get; set; }
         public uint rtime_last_played { get; set; }
+
+        public bool IncludePlaytime { get; set; }
+
+        public GameMetadata ToGame()
+        {
+            var output = new GameMetadata
+            {
+                GameId = Id,
+                Name = name.RemoveTrademarks().Trim(),
+                Platforms = new HashSet<MetadataProperty> {new MetadataSpecProperty("pc_windows")},
+                Source = SourceNames.GetSource(IsOwned, BackendAppInfo?.Type),
+            };
+
+            if (IncludePlaytime)
+            {
+                output.Playtime = playtime_forever * 60;
+                output.LastActivity = SteamApiServiceBase.GetLastPlayedDateTime(rtime_last_played);
+            }
+
+            return output;
+        }
+
+        public GameID Id => (uint) appid;
+        public bool IsOwned => true;
+        public BackendAppInfo BackendAppInfo { get; set; }
+
+    }
+
+    public interface ISteamApp
+    {
+        GameID Id { get; }
+        GameMetadata ToGame();
+        public BackendAppInfo BackendAppInfo { get; set; }
+        bool IsOwned { get; }
+    }
+
+    public class LocalSteamApp : ISteamApp
+    {
+        public GameID Id { get; set; }
+        public string Name { get; set; }
+        public string InstallDir { get; set; }
+
+        public GameMetadata ToGame()
+        {
+            return new GameMetadata()
+            {
+                GameId = Id,
+                Name = Name,
+                InstallDirectory = InstallDir,
+                IsInstalled = true,
+                Platforms = new HashSet<MetadataProperty> { new MetadataSpecProperty("pc_windows") },
+                Source = SourceNames.GetSource(IsOwned, BackendAppInfo?.Type),
+            };
+        }
+
+        public bool IsOwned => true;
+        public BackendAppInfo BackendAppInfo { get; set; }
+
+    }
+
+    public class ExtraIdSteamApp : ISteamApp
+    {
+        public GameID Id { get; set; }
+        public string Name { get; set; }
+
+        public GameMetadata ToGame()
+        {
+            return new GameMetadata
+            {
+                GameId = Id,
+                Name = Name,
+                Platforms = new HashSet<MetadataProperty> { new MetadataSpecProperty("pc_windows") },
+                Source = SourceNames.GetSource(IsOwned, BackendAppInfo?.Type),
+            };
+        }
+
+        public bool IsOwned => true;
+        public BackendAppInfo BackendAppInfo { get; set; }
+
+    }
+
+    public class BackendOwnSteamDbApp : ISteamApp
+    {
+        public BackendOwnSteamDbApp(BackendAppInfo item)
+        {
+            BackendAppInfo = item;
+        }
+
+        public GameMetadata ToGame() =>
+            new GameMetadata
+            {
+                Name = BackendAppInfo.Name.RemoveTrademarks(),
+                GameId = Id,
+                Platforms = new HashSet<MetadataProperty> {new MetadataSpecProperty("pc_windows")},
+                Source = SourceNames.GetSource(IsOwned, BackendAppInfo?.Type),
+            };
+
+        public GameID Id => BackendAppInfo.AppId;
+        public bool IsOwned => true;
+        public BackendAppInfo BackendAppInfo { get; set; }
     }
 }

--- a/source/Libraries/SteamLibrary/Models/BackendModels.cs
+++ b/source/Libraries/SteamLibrary/Models/BackendModels.cs
@@ -1,0 +1,54 @@
+#nullable enable
+using System.Collections.Generic;
+
+namespace SteamLibrary.Models
+{
+    // TODO move to playnite backend repo
+    public class BackendSteamDbItemsRequest
+    {
+        public List<ulong>? AppIds { get; set; }
+    }
+
+    /// <summary>
+    /// Playnite backend metadata for steam app
+    /// </summary>
+    public class BackendAppInfo
+    {
+        private string? type;
+        public uint AppId { get; set; }
+
+        public string? Name
+        {
+            get => name ?? $"Unknown App {AppId}";
+            set => name = value;
+        }
+
+        /// <summary>
+        /// Normalized to lowercase. Original metadata has "Game" and "game" values
+        /// </summary>
+        public string? Type
+        {
+            get => type?.ToLowerInvariant() ?? "unknown";
+            set => type = value;
+        }
+
+        public bool IsGame => Type == "game";
+        public bool IsFree => Type == "demo" || Type == "beta";
+        public bool IsApp => Type == "application";
+        public bool IsMedia => Type == "music" || Type == "video";
+        public bool IsTool => Type == "tool";
+        public bool IsUseless => Type == "config" || Type == "dlc" || Type == "unknown";
+
+        public Dictionary<string, string>? LocalizedNames { get; set; }
+
+        public void LocalizeName(string lang)
+        {
+            if (LocalizedNames?.TryGetValue(lang, out var appName) == true && !string.IsNullOrWhiteSpace(appName))
+            {
+                Name = appName;
+            }
+        }
+
+        private string? name;
+    }
+}

--- a/source/Libraries/SteamLibrary/Services/Base/SteamApiServiceBase.cs
+++ b/source/Libraries/SteamLibrary/Services/Base/SteamApiServiceBase.cs
@@ -57,7 +57,7 @@ namespace SteamLibrary.Services.Base
             }
         }
 
-        protected static DateTime? GetLastPlayedDateTime(uint unixEpochSeconds)
+        public static DateTime? GetLastPlayedDateTime(uint unixEpochSeconds)
         {
             if (unixEpochSeconds == 0)
                 return null;

--- a/source/Libraries/SteamLibrary/Services/ClientCommService.cs
+++ b/source/Libraries/SteamLibrary/Services/ClientCommService.cs
@@ -1,7 +1,5 @@
-using Playnite.SDK.Models;
 using SteamLibrary.Models;
 using SteamLibrary.Services.Base;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -13,38 +11,22 @@ namespace SteamLibrary.Services
     /// </summary>
     public class ClientCommService : SteamApiServiceBase
     {
-        public IEnumerable<GameMetadata> GetClientAppList(SteamLibrarySettings settings, SteamUserToken userToken)
+        /// <summary>
+        /// IClientCommService/GetClientAppList
+        /// </summary>
+        public IEnumerable<ISteamApp> GetClientAppList(SteamLibrarySettings settings, SteamUserToken userToken)
         {
             var response = Get<GetClientAppListResponse>("https://api.steampowered.com/IClientCommService/GetClientAppList/v1/",
                                                          new Dictionary<string, string>
                                                          {
-                                                             { "fields", "games" }, // could also add tools here like so: games|tools
+                                                             { "fields", "all" },
                                                              { "access_token", userToken.AccessToken },
                                                              { "language", settings.LanguageKey },
                                                          });
 
-            return response?.apps?.Select(ToGame)
-                   ?? Enumerable.Empty<GameMetadata>();
+            return response?.apps ?? Enumerable.Empty<ISteamApp>();
         }
 
-        private static GameMetadata ToGame(SteamClientApp app)
-        {
-            return new GameMetadata
-            {
-                GameId = app.appid.ToString(),
-                Name = app.app.RemoveTrademarks().Trim(),
-                InstallSize = GetInstallSize(app),
-                Platforms = new HashSet<MetadataProperty> { new MetadataSpecProperty("pc_windows") },
-                Source = new MetadataNameProperty(SourceNames.Steam)
-            };
-        }
 
-        private static ulong? GetInstallSize(SteamClientApp app)
-        {
-            if (ulong.TryParse(app.bytes_required, out ulong size))
-                return size;
-
-            return null;
-        }
     }
 }

--- a/source/Libraries/SteamLibrary/Services/FamilyGroupsService.cs
+++ b/source/Libraries/SteamLibrary/Services/FamilyGroupsService.cs
@@ -1,7 +1,5 @@
-using Playnite.SDK.Models;
 using SteamLibrary.Models;
 using SteamLibrary.Services.Base;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -9,56 +7,63 @@ namespace SteamLibrary.Services
 {
     public class FamilyGroupsService : SteamApiServiceBase
     {
-        public IEnumerable<GameMetadata> GetSharedGames(SteamLibrarySettings settings, SteamUserToken userToken, out HashSet<string> userIds)
+        /// <summary>
+        /// IFamilyGroupsService/GetSharedLibraryApps
+        /// </summary>
+        public IEnumerable<ISteamApp> GetSharedGames(SteamLibrarySettings settings, SteamUserToken userToken, HashSet<string> userIds)
         {
-            userIds = new HashSet<string>();
             var familyGroup = GetFamilyGroupForUser(userToken);
             if (familyGroup.is_not_member_of_any_group)
-                return Enumerable.Empty<GameMetadata>();
+                return Enumerable.Empty<ISteamApp>();
 
             var sharedLibrary = GetSharedLibraryApps(settings, userToken, familyGroup.family_groupid);
 
             if (sharedLibrary.apps == null) //user is most likely in a family group without any other members
-                return Enumerable.Empty<GameMetadata>();
+                return Enumerable.Empty<ISteamApp>();
 
-            userIds = sharedLibrary.apps.SelectMany(a => a.owner_steamids).ToHashSet();
+            userIds.UnionWith(sharedLibrary.apps.SelectMany(a => a.owner_steamids));
+            var currentOwner = sharedLibrary.owner_steamid;
+            foreach (var app in sharedLibrary.apps)
+            {
+                // steam lies about ownership: currentOwner in the list, but game has exclude_reason - meaning it's free, coming from family
+                app.IsOwned = app.owner_steamids.Contains(currentOwner) && app.exclude_reason == 0;
+            }
 
-            return sharedLibrary.apps.Select(ToGame);
+            return sharedLibrary.apps.Where(x => x.IsImportable);
         }
 
+
+
+        /// <summary>
+        /// IFamilyGroupsService/GetFamilyGroupForUser
+        /// </summary>
         private GetFamilyGroupForUserResponse GetFamilyGroupForUser(SteamUserToken userToken)
         {
             return Get<GetFamilyGroupForUserResponse>("https://api.steampowered.com/IFamilyGroupsService/GetFamilyGroupForUser/v1/",
                                                       new Dictionary<string, string>
                                                       {
                                                           { "access_token", userToken.AccessToken },
-                                                          { "steamid", userToken.UserId.ToString() },
                                                       });
         }
 
+        /// <summary>
+        /// IFamilyGroupsService/GetSharedLibraryApps
+        /// </summary>
         private GetSharedLibraryAppsResponse GetSharedLibraryApps(SteamLibrarySettings settings, SteamUserToken userToken, string familyGroupId)
         {
             return Get<GetSharedLibraryAppsResponse>("https://api.steampowered.com/IFamilyGroupsService/GetSharedLibraryApps/v1/",
                                                      new Dictionary<string, string>
                                                      {
                                                          { "access_token", userToken.AccessToken },
-                                                         { "steamid", userToken.UserId.ToString() },
                                                          { "family_groupid", familyGroupId },
                                                          { "language", settings.LanguageKey },
+                                                         { "include_own", "true" },
+                                                         { "include_excluded", "true" },
+                                                         { "include_free", "true" },
+                                                         { "include_non_games", "true" },
                                                      });
         }
 
-        private static GameMetadata ToGame(FamilySharedApp sharedApp)
-        {
-            return new GameMetadata
-            {
-                GameId = sharedApp.appid.ToString(),
-                Name = sharedApp.name.RemoveTrademarks().Trim(),
-                LastActivity = GetLastPlayedDateTime(sharedApp.rt_last_played),
-                Playtime = sharedApp.rt_playtime * 60,
-                Platforms = new HashSet<MetadataProperty> { new MetadataSpecProperty("pc_windows") },
-                Source = new MetadataNameProperty(SourceNames.FamilySharing)
-            };
-        }
+
     }
 }

--- a/source/Libraries/SteamLibrary/Services/PlayerService.cs
+++ b/source/Libraries/SteamLibrary/Services/PlayerService.cs
@@ -1,21 +1,24 @@
-using Playnite.SDK.Models;
 using SteamLibrary.Models;
 using SteamLibrary.Services.Base;
-using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace SteamLibrary.Services
 {
     public class PlayerService : SteamApiServiceBase
     {
-        public IEnumerable<GameMetadata> GetOwnedGamesWeb(SteamLibrarySettings settings, SteamUserToken userToken, bool freeSub) =>
-            PlayerServiceGetOwnedGames(settings, userToken.UserId, "access_token", userToken.AccessToken, freeSub, true);
+        /// <summary>
+        /// IPlayerService/GetOwnedGames
+        /// </summary>
+        public IEnumerable<ISteamApp> GetOwnedGamesWeb(SteamLibrarySettings settings, SteamUserToken userToken) =>
+            PlayerServiceGetOwnedGames(settings, userToken.UserId, "access_token", userToken.AccessToken, true);
 
-        public IEnumerable<GameMetadata> GetOwnedGamesApiKey(SteamLibrarySettings settings, ulong userId, string apiKey, bool freeSub, bool includePlaytime = true) =>
-            PlayerServiceGetOwnedGames(settings, userId, "key", apiKey, freeSub, includePlaytime);
+        /// <summary>
+        /// IPlayerService/GetOwnedGames
+        /// </summary>
+        public IEnumerable<ISteamApp> GetOwnedGamesApiKey(SteamLibrarySettings settings, ulong userId, string apiKey, bool includePlaytime = true) =>
+            PlayerServiceGetOwnedGames(settings, userId, "key", apiKey, includePlaytime);
 
-        private IEnumerable<GameMetadata> PlayerServiceGetOwnedGames(SteamLibrarySettings settings, ulong userId, string keyType, string key, bool freeSub, bool includePlaytime)
+        private IEnumerable<ISteamApp> PlayerServiceGetOwnedGames(SteamLibrarySettings settings, ulong userId, string keyType, string key, bool includePlaytime)
         {
             // For some reason Steam Web API likes to return 429 even if you
             // don't make a request in several hours, so just retry couple times.
@@ -27,30 +30,18 @@ namespace SteamLibrary.Services
                 { "steamid", userId.ToString() },
                 { "include_appinfo", "true" },
                 { "include_played_free_games", "true" },
-                { "include_free_sub", freeSub.ToString() },
+                { "include_free_sub", "true" },
+                { "skip_unvetted_apps", "false" },
                 { "language", settings.LanguageKey },
             };
             var response = Get<GetOwnedGamesResponse>("https://api.steampowered.com/IPlayerService/GetOwnedGames/v1/", parameters, retrySettings);
-            return response.games.Select(g => ToGame(g, includePlaytime));
-        }
-
-        private static GameMetadata ToGame(OwnedGame game, bool includePlaytime)
-        {
-            var output = new GameMetadata
+            foreach (var game in response.games)
             {
-                GameId = game.appid.ToString(),
-                Name = game.name.RemoveTrademarks().Trim(),
-                Platforms = new HashSet<MetadataProperty> { new MetadataSpecProperty("pc_windows") },
-                Source = new MetadataNameProperty(SourceNames.Steam),
-            };
-
-            if (includePlaytime)
-            {
-                output.Playtime = game.playtime_forever * 60;
-                output.LastActivity = GetLastPlayedDateTime(game.rtime_last_played);
+                game.IncludePlaytime = includePlaytime;
             }
-
-            return output;
+            return response.games;
         }
+
+
     }
 }

--- a/source/Libraries/SteamLibrary/Services/SourceNames.cs
+++ b/source/Libraries/SteamLibrary/Services/SourceNames.cs
@@ -1,9 +1,32 @@
+using Playnite.SDK.Models;
+
 namespace SteamLibrary.Services
 {
     public static class SourceNames
     {
         public const string Steam = "Steam";
+        public const string Extras = "Steam Extras";
+        public const string Video = "Steam Video";
         public const string FamilySharing = "Steam Family Sharing";
-        public static readonly string[] AllKnown = { Steam, FamilySharing };
+        public const string FamilySharingExtras = "Steam Family Sharing Extras";
+        public static readonly string[] AllKnown = {Steam, FamilySharing, Extras, FamilySharingExtras, Video};
+
+        // TODO i don't really see a good way to cram type (game/app/media/etc) and ownership (own/family) into one "source" property
+        // it was ok for gog and epic but this is starting to look insane
+        // also videos need to launch browser instead of installing, i decided not to break steam ids and encode this info here
+        // all this infinitely debatable, for example should apps not be labeled "extras"?..
+        // maybe make an option to create tags with type, ownership, whatever else?
+        public static MetadataNameProperty GetSource(bool isOwned, string type)
+        {
+            var source = type switch
+            {
+                "video" => Video,
+                "game" when isOwned => Steam,
+                "game" => FamilySharing,
+                _ when isOwned => Extras,
+                _ => FamilySharingExtras
+            };
+            return new MetadataNameProperty(source);
+        }
     }
 }

--- a/source/Libraries/SteamLibrary/Services/SteamLocalService.cs
+++ b/source/Libraries/SteamLibrary/Services/SteamLocalService.cs
@@ -1,12 +1,12 @@
 using Playnite.Common;
 using Playnite.SDK;
-using Playnite.SDK.Models;
 using SteamKit2;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using SteamLibrary.Models;
 
 namespace SteamLibrary.Services
 {
@@ -69,7 +69,7 @@ namespace SteamLibrary.Services
             return result;
         }
 
-        internal static GameMetadata GetInstalledGameFromFile(string path)
+        internal static LocalSteamApp GetInstalledGameFromFile(string path)
         {
             var kv = new KeyValue();
             using (var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
@@ -113,22 +113,17 @@ namespace SteamLibrary.Services
                 }
             }
 
-            var game = new GameMetadata()
+            return new LocalSteamApp()
             {
-                // no source because normal/family sharing source is determined later in SteamServiceAggregator
-                GameId = gameId.ToString(),
+                Id = gameId,
                 Name = name.RemoveTrademarks().Trim(),
-                InstallDirectory = installDir,
-                IsInstalled = true,
-                Platforms = new HashSet<MetadataProperty> { new MetadataSpecProperty("pc_windows") }
+                InstallDir = installDir
             };
-
-            return game;
         }
 
-        internal static List<GameMetadata> GetInstalledGamesFromFolder(string path)
+        internal static List<LocalSteamApp> GetInstalledGamesFromFolder(string path)
         {
-            var games = new List<GameMetadata>();
+            var games = new List<LocalSteamApp>();
 
             foreach (var file in Directory.GetFiles(path, @"appmanifest*"))
             {
@@ -145,7 +140,7 @@ namespace SteamLibrary.Services
                         continue;
                     }
 
-                    if (game.InstallDirectory.IsNullOrEmpty() || game.InstallDirectory.Contains(@"steamapps\music"))
+                    if (game.InstallDir.IsNullOrEmpty() || game.InstallDir.Contains(@"steamapps\music"))
                     {
                         logger.Info($"Steam game {game.Name} is not properly installed or it's a soundtrack, skipping.");
                         continue;
@@ -163,9 +158,9 @@ namespace SteamLibrary.Services
             return games;
         }
 
-        internal static List<GameMetadata> GetInstalledGoldSrcModsFromFolder(string path)
+        internal static List<ModInfo> GetInstalledGoldSrcModsFromFolder(string path)
         {
-            var games = new List<GameMetadata>();
+            var games = new List<ModInfo>();
             var dirInfo = new DirectoryInfo(path);
 
             foreach (var folder in dirInfo.GetDirectories().Where(a => !firstPartyModPrefixes.Any(prefix => a.Name.StartsWith(prefix))).Select(a => a.FullName))
@@ -188,9 +183,9 @@ namespace SteamLibrary.Services
             return games;
         }
 
-        internal static List<GameMetadata> GetInstalledSourceModsFromFolder(string path)
+        internal static List<ModInfo> GetInstalledSourceModsFromFolder(string path)
         {
-            var games = new List<GameMetadata>();
+            var games = new List<ModInfo>();
 
             foreach (var folder in Directory.GetDirectories(path))
             {
@@ -212,38 +207,14 @@ namespace SteamLibrary.Services
             return games;
         }
 
-        internal static GameMetadata GetInstalledModFromFolder(string path, ModInfo.ModType modType)
+        internal static ModInfo GetInstalledModFromFolder(string path, ModInfo.ModType modType)
         {
-            var modInfo = ModInfo.GetFromFolder(path, modType);
-            if (modInfo == null)
-            {
-                return null;
-            }
-
-            var game = new GameMetadata
-            {
-                Source = new MetadataNameProperty(SourceNames.Steam),
-                GameId = modInfo.GameId.ToString(),
-                Name = modInfo.Name.RemoveTrademarks().Trim(),
-                InstallDirectory = path,
-                IsInstalled = true,
-                Developers = new HashSet<MetadataProperty> { new MetadataNameProperty(modInfo.Developer) },
-                Links = modInfo.Links,
-                Tags = modInfo.Categories?.Select(a => new MetadataNameProperty(a)).Cast<MetadataProperty>().ToHashSet(),
-                Platforms = new HashSet<MetadataProperty> { new MetadataSpecProperty("pc_windows") }
-            };
-
-            if (!modInfo.IconPath.IsNullOrEmpty() && File.Exists(modInfo.IconPath))
-            {
-                game.Icon = new MetadataFile(modInfo.IconPath);
-            }
-
-            return game;
+            return ModInfo.GetFromFolder(path, modType);
         }
 
-        internal static Dictionary<string, GameMetadata> GetInstalledGames(bool includeMods = true)
+        internal static Dictionary<string, ISteamApp> GetInstalledGames(bool includeMods)
         {
-            var games = new Dictionary<string, GameMetadata>();
+            var games = new Dictionary<string, ISteamApp>();
             if (!Steam.IsInstalled)
             {
                 throw new Exception("Steam installation not found.");
@@ -257,14 +228,14 @@ namespace SteamLibrary.Services
                     GetInstalledGamesFromFolder(libFolder).ForEach(a =>
                     {
                         // Ignore redist
-                        if (a.GameId == "228980")
+                        if (a.Id == "228980")
                         {
                             return;
                         }
 
-                        if (!games.ContainsKey(a.GameId))
+                        if (!games.ContainsKey(a.Id))
                         {
-                            games.Add(a.GameId, a);
+                            games.Add(a.Id, a);
                         }
                     });
                 }
@@ -284,9 +255,9 @@ namespace SteamLibrary.Services
                     {
                         GetInstalledGoldSrcModsFromFolder(Steam.ModInstallPath).ForEach(a =>
                         {
-                            if (!games.ContainsKey(a.GameId))
+                            if (!games.ContainsKey(a.Id))
                             {
-                                games.Add(a.GameId, a);
+                                games.Add(a.Id, a);
                             }
                         });
                     }
@@ -297,9 +268,9 @@ namespace SteamLibrary.Services
                     {
                         GetInstalledSourceModsFromFolder(Steam.SourceModInstallPath).ForEach(a =>
                         {
-                            if (!games.ContainsKey(a.GameId))
+                            if (!games.ContainsKey(a.Id))
                             {
-                                games.Add(a.GameId, a);
+                                games.Add(a.Id, a);
                             }
                         });
                     }

--- a/source/Libraries/SteamLibrary/Services/SteamServiceAggregator.cs
+++ b/source/Libraries/SteamLibrary/Services/SteamServiceAggregator.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using SteamLibrary.Models;
 
 namespace SteamLibrary.Services
 {
@@ -35,7 +36,6 @@ namespace SteamLibrary.Services
         public async Task<IEnumerable<GameMetadata>> GetGamesAsync(SteamLibrarySettings settings)
         {
             var installedGameIds = new HashSet<string>();
-
             var allGames = new Dictionary<string, GameMetadata>();
             Exception importError = null;
 
@@ -61,17 +61,39 @@ namespace SteamLibrary.Services
                         if (existingGame.Playtime == 0)
                             existingGame.Playtime = game.Playtime;
 
-                        if (existingGame.Source == null)
-                            existingGame.Source = game.Source;
+                        existingGame.Source = game.Source;
                     }
                 }
             }
 
-            bool TryAddGames(Func<IEnumerable<GameMetadata>> getGamesFunc, string importSource, HashSet<string> gameIdsOutput = null, bool overwriteName = false)
+            bool TryAddGames(Func<IEnumerable<ISteamApp>> getGamesFunc, string importSource, HashSet<string> gameIdsOutput = null, bool overwriteName = false)
             {
                 try
                 {
-                    var games = getGamesFunc().ToList();
+                    var apps = getGamesFunc().ToList();
+                    var query = apps.Where(x => x.BackendAppInfo is null)
+                        .Select(x => x.Id)
+                        .Distinct()
+                        .ToList();
+                    var infos = playniteBackend.GetAppInfo(query).Result.ToDictionary(x => x.AppId);
+                    foreach (var app in apps)
+                    {
+                        if (infos.TryGetValue((uint) app.Id.ToUInt64(), out var info))
+                        {
+                            app.BackendAppInfo = info;
+                        }
+
+                        if (string.IsNullOrWhiteSpace(app.BackendAppInfo.Name) || string.IsNullOrWhiteSpace(app.BackendAppInfo.Type))
+                        {
+                            logger.Warn($"{app.Id} own={app.IsOwned} incomplete backend info: [{app.BackendAppInfo!.Name}] [{app.BackendAppInfo.Type}]");
+                        }
+                    }
+
+                    var games = apps
+                        .Where(x => Filter(x, settings))
+                        .Select(x => x.ToGame())
+                        .ToList();
+
                     logger.Info($"Found {games.Count} {importSource} Steam games.");
                     AddGames(games, overwriteName);
 
@@ -89,40 +111,69 @@ namespace SteamLibrary.Services
                 }
             }
 
-            if (settings.ImportInstalledGames)
-                TryAddGames(() => SteamLocalService.GetInstalledGames().Values, "Installed", installedGameIds);
+            if (settings.ImportInstalled)
+            {
+                TryAddGames(() => SteamLocalService.GetInstalledGames(settings.ImportInstalledMods).Values, "Installed", installedGameIds);
+            }
 
             if (settings.ConnectAccount)
             {
-                var onlineLibraryGameIds = new HashSet<string>();
+                var importedOnlineOwn = new HashSet<string>();
+                var importedOnlineFamily = new HashSet<string>();
                 var familySharingUserIds = new HashSet<string>();
-
-                if (settings.IsPrivateAccount)
+                if (settings.UseApiLogin)
                 {
                     if (settings.UserId.IsNullOrEmpty())
                     {
                         throw new Exception(playniteApi.Resources.GetString(LOC.SteamNotLoggedInError));
                     }
 
-                    TryAddGames(() => playerService.GetOwnedGamesApiKey(settings, ulong.Parse(settings.UserId), settings.RuntimeApiKey, settings.IncludeFreeSubGames), "PlayerService (API key)", onlineLibraryGameIds, true);
+                    TryAddGames(() => playerService.GetOwnedGamesApiKey(settings, ulong.Parse(settings.UserId), settings.RuntimeApiKey), "PlayerService (API key)", importedOnlineOwn, true);
                 }
                 else
                 {
                     try
                     {
                         var userToken = await storeService.GetAccessTokenAsync();
-                        TryAddGames(() => playerService.GetOwnedGamesWeb(settings, userToken, settings.IncludeFreeSubGames), "PlayerService (access token)", onlineLibraryGameIds, true);
+                        // endpoint query order is important: if a game gets imported as own and from family, "Steam" source should win
 
-                        if (!TryAddGames(() => clientCommService.GetClientAppList(settings, userToken), "GetClientAppList", onlineLibraryGameIds, true))
-                            TryAddGames(() => GetSteamStoreGamesAsync(settings, allGames).GetAwaiter().GetResult(), "userdata", onlineLibraryGameIds);
+                        if (settings.ImportGamesFamily || settings.ImportFreeFamily || settings.ImportToolsFamily || settings.ImportToolsOwn)
+                        {
+                            // game, demo, beta, tool - returns family content
+                            // also required to filter out family tools that steam wrongly displays as own
+                            // also returns all tools
+                            var familyGames = familyGroupsService.GetSharedGames(settings, userToken, familySharingUserIds);
+                            TryAddGames(() => familyGames, "Family Sharing", importedOnlineFamily, true);
+                        }
 
-                        if (settings.ImportFamilySharedGames)
-                            TryAddGames(() => familyGroupsService.GetSharedGames(settings, userToken, out familySharingUserIds), "Family Sharing", onlineLibraryGameIds, true);
+                        /*if (settings.ImportFreeOwn)
+                        {
+                            // demo - returns inconclusive data. better results with next endpoint, this can be skipped entirely
+                            var ownedGames = playerService.GetOwnedGamesWeb(settings, userToken);
+                            TryAddGames(() => ownedGames, "PlayerService (access token)", importedOnlineOwn, true);
+                        }*/
+
+                        if (settings.ImportFreeOwn || settings.ImportToolsOwn)
+                        {
+                            // demo, tool - returns all demos and some tools
+                            // works only when steam client is running. there is a note in UI about that
+                            var clientGames = clientCommService.GetClientAppList(settings, userToken).ToList();
+                            //FixToolsOwnership(clientGames, importedOnlineFamily);
+                            TryAddGames(() => clientGames, "GetClientAppList", importedOnlineOwn, true);
+                        }
+
+                        if (settings.ImportGamesOwn || settings.ImportAppsOwn || settings.ImportMediaOwn || settings.ImportFreeOwn)
+                        {
+                            // game, app, media, beta - returns everything perfectly without any issues
+                            // no need to query anything else for these types
+                            var userdataGames = await GetUserdataGamesAsync(settings);
+                            TryAddGames(() => userdataGames, "userdata", importedOnlineOwn, true);
+                        }
                     }
                     catch (Exception e)
                     {
                         importError = e;
-                        logger.Error(e, "Failed to get access token for Steam account.");
+                        logger.Error(e, "Failed to import Steam games");
                     }
                 }
 
@@ -131,13 +182,14 @@ namespace SteamLibrary.Services
                     if (familySharingUserIds.Contains(extraAccount.Item1.ToString()))
                         logger.Info($"Skipped extra account import for {extraAccount.Item1} because it's in the family sharing group");
                     else
-                        TryAddGames(() => playerService.GetOwnedGamesApiKey(settings, extraAccount.Item1, extraAccount.Item2, false, false), $"Extra Account ({extraAccount.Item1})", onlineLibraryGameIds, true);
+                        TryAddGames(() => playerService.GetOwnedGamesApiKey(settings, extraAccount.Item1, extraAccount.Item2, false), $"Extra Account ({extraAccount.Item1})", importedOnlineOwn, true);
                 }
 
-                if (settings.IgnoreOtherInstalled)
+                if (settings.ImportInstalledIgnoreOthers)
                 {
-                    var idsOfInstalledGamesFromAccountsNotUnderUserControl = installedGameIds.Except(onlineLibraryGameIds).ToList();
-                    foreach (var installedGameId in idsOfInstalledGamesFromAccountsNotUnderUserControl)
+                    // when a foreign game is installed AND also imported from family, there is no reason to exclude it
+                    var installedNotOwnedNotFamily = installedGameIds.Except(importedOnlineOwn).Except(importedOnlineFamily);
+                    foreach (var installedGameId in installedNotOwnedNotFamily)
                     {
                         if (IsModId(installedGameId))
                             continue;
@@ -163,50 +215,99 @@ namespace SteamLibrary.Services
                 playniteApi.Notifications.Remove(plugin.ImportErrorMessageId);
             }
 
-            var output = allGames.Values.Where(g => !g.Name.IsNullOrWhiteSpace() && (g.IsInstalled || settings.ImportUninstalledGames)).ToList();
-
-            foreach (var game in output.Where(g => g.Source == null)) //installed games don't get a source by default
+            foreach (var unnamed in allGames.Where(x => x.Value.Name.IsNullOrWhiteSpace()))
             {
-                game.Source = new MetadataNameProperty(SourceNames.Steam);
+                var game = unnamed.Value;
+                logger.Warn($"Unnamed game [{game.GameId}]");
+                allGames.Remove(unnamed.Key);
             }
 
+            var output = allGames.Values.ToList();
             UpdateExistingGames(output);
-
             return output;
         }
 
-        private async Task<IEnumerable<GameMetadata>> GetSteamStoreGamesAsync(SteamLibrarySettings settings, Dictionary<string, GameMetadata> pendingImportGames)
+        private bool Filter(ISteamApp app, SteamLibrarySettings settings)
         {
-            var appIds = (await storeService.GetUserDataAsync()).rgOwnedApps;
+            var b = app.BackendAppInfo;
+            logger.Debug($"FILTER [{app.Id}] [{b.Name}] {app.GetType().Name} {b.Type} useless={b.IsUseless} game={b.IsGame} app={b.IsApp} media={b.IsMedia} free={b.IsFree} tool={b.IsTool} own={app.IsOwned}");
 
-            var existingLibraryIds = playniteApi.Database.Games.Where(g => g.PluginId == plugin.Id).Select(g => g.GameId).ToHashSet();
-
-            var newAppIds = appIds.Where(id =>
+            if (b.IsUseless)
             {
-                var strId = id.ToString();
-                return !pendingImportGames.ContainsKey(strId)
-                       && !existingLibraryIds.Contains(strId);
-            }).ToList();
+                return false;
+            }
 
-            var appInfos = playniteBackend.GetAppInfos(newAppIds).Result;
-
-            var output = new List<GameMetadata>();
-
-            foreach (var appInfo in appInfos)
+            if (app is LocalSteamApp && settings.ImportInstalled)
             {
-                if (appInfo.LocalizedNames?.TryGetValue(settings.LanguageKey, out var appName) != true || string.IsNullOrWhiteSpace(appName))
-                    appName = appInfo.Name;
+                return true;
+            }
 
-                if (string.IsNullOrWhiteSpace(appName) || !"game".Equals(appInfo.Type, StringComparison.OrdinalIgnoreCase))
-                    continue;
+            if (app is ModInfo && settings.ImportInstalledMods)
+            {
+                return true;
+            }
 
-                output.Add(new GameMetadata
-                {
-                    Name = appName.RemoveTrademarks(),
-                    GameId = appInfo.AppId.ToString(),
-                    Platforms = new HashSet<MetadataProperty> { new MetadataSpecProperty("pc_windows") },
-                    Source = new MetadataNameProperty(SourceNames.Steam),
-                });
+            if (app is ExtraIdSteamApp)
+            {
+                return true;
+            }
+
+            if (b.IsGame && app.IsOwned && settings.ImportGamesOwn)
+            {
+                return true;
+            }
+
+            if (b.IsGame && !app.IsOwned && settings.ImportGamesFamily)
+            {
+                return true;
+            }
+
+            if (b.IsApp && settings.ImportAppsOwn)
+            {
+                return true;
+            }
+
+            if (b.IsMedia && settings.ImportMediaOwn)
+            {
+                return true;
+            }
+
+            if (b.IsFree && app.IsOwned && settings.ImportFreeOwn)
+            {
+                return true;
+            }
+
+            if (b.IsFree && !app.IsOwned && settings.ImportFreeFamily)
+            {
+                return true;
+            }
+
+            if (b.IsTool && app.IsOwned && settings.ImportToolsOwn)
+            {
+                return true;
+            }
+
+            if (b.IsTool && !app.IsOwned && settings.ImportToolsFamily)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// dynamicstore/userdata + playnite backend
+        /// </summary>
+        private async Task<IEnumerable<ISteamApp>> GetUserdataGamesAsync(SteamLibrarySettings settings)
+        {
+            var userdata = await storeService.GetUserDataAsync();
+            var appIds = userdata.rgOwnedApps.Select(x => new GameID(x)).ToList();
+            var appInfos = await playniteBackend.GetAppInfo(appIds);
+            var output = new List<ISteamApp>();
+            foreach (var app in appInfos)
+            {
+                app.LocalizeName(settings.LanguageKey);
+                output.Add(new BackendOwnSteamDbApp(app));
             }
             return output;
         }
@@ -266,7 +367,7 @@ namespace SteamLibrary.Services
 
         private static bool IsModId(string gameId) => new GameID(ulong.Parse(gameId)).IsMod;
 
-        private IEnumerable<GameMetadata> GetGamesFromExtraIds(SteamLibrarySettings settings)
+        private IEnumerable<ISteamApp> GetGamesFromExtraIds(SteamLibrarySettings settings)
         {
             if (!settings.ExtraIDsToImport.HasItems())
                 yield break;
@@ -279,12 +380,10 @@ namespace SteamLibrary.Services
                     continue;
                 }
 
-                yield return new GameMetadata
+                yield return new ExtraIdSteamApp()
                 {
-                    GameId = parseResult.Item1,
+                    Id = uint.Parse(parseResult.Item1),
                     Name = parseResult.Item2,
-                    Source = new MetadataNameProperty(SourceNames.Steam),
-                    Platforms = new HashSet<MetadataProperty> { new MetadataSpecProperty("pc_windows") }
                 };
             }
         }

--- a/source/Libraries/SteamLibrary/Services/SteamServicesClient.cs
+++ b/source/Libraries/SteamLibrary/Services/SteamServicesClient.cs
@@ -1,13 +1,10 @@
-﻿using Playnite.Backend.Steam;
-using Playnite.SDK;
+﻿using Playnite.SDK;
 using PlayniteExtensions.Common;
-using SteamLibrary.Models;
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
-using System.Text;
 using System.Threading.Tasks;
+using SteamKit2;
+using SteamLibrary.Models;
 
 namespace SteamLibrary.Services
 {
@@ -19,14 +16,19 @@ namespace SteamLibrary.Services
         {
         }
 
-        public async Task<List<SteamDbItem>> GetAppInfos(List<uint> appIds)
+        /// <summary>
+        /// steam/appinfo
+        /// </summary>
+        public async Task<List<BackendAppInfo>> GetAppInfo(List<GameID> appIds)
         {
-            var request = new SteamDbItemsRequest()
-            { 
-                AppIds = appIds
+            // TODO local cache maybe?
+            var ids = appIds.Select(x => x.ToUInt64()).ToList();
+            var request = new BackendSteamDbItemsRequest()
+            {
+                AppIds = ids
             };
 
-            return await PostRequest<List<SteamDbItem>>("steam/appinfo", request);
+            return await PostRequest<List<BackendAppInfo>>("steam/appinfo", request);
         }
     }
 }

--- a/source/Libraries/SteamLibrary/Services/SteamStoreService.cs
+++ b/source/Libraries/SteamLibrary/Services/SteamStoreService.cs
@@ -1,5 +1,4 @@
 using AngleSharp.Parser.Html;
-using Newtonsoft.Json;
 using Playnite.SDK;
 using Playnite.SDK.Events;
 using SteamLibrary.Models;
@@ -8,6 +7,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Playnite.SDK.Data;
 
 namespace SteamLibrary.Services
 {
@@ -23,6 +23,9 @@ namespace SteamLibrary.Services
             PlayniteApi = playniteApi;
         }
 
+        /// <summary>
+        /// dynamicstore/userdata
+        /// </summary>
         public async Task<SteamUserDataRoot> GetUserDataAsync()
         {
             var str = await DownloadPageSourceAsync("https://store.steampowered.com/dynamicstore/userdata/");
@@ -34,7 +37,7 @@ namespace SteamLibrary.Services
                 str = doc.GetElementsByTagName("body").FirstOrDefault()?.TextContent;
             }
 
-            var model = JsonConvert.DeserializeObject<SteamUserDataRoot>(str);
+            var model = Serialization.FromJson<SteamUserDataRoot>(str);
             return model;
         }
 

--- a/source/Libraries/SteamLibrary/SteamGameController.cs
+++ b/source/Libraries/SteamLibrary/SteamGameController.cs
@@ -28,6 +28,11 @@ namespace SteamLibrary
 
         public override void Install(InstallActionArgs args)
         {
+            if (HandleVideos())
+            {
+                return;
+            }
+
             if (!Steam.IsInstalled)
             {
                 throw new Exception("Steam installation not found.");
@@ -61,9 +66,10 @@ namespace SteamLibrary
                     var installed = SteamLocalService.GetInstalledGames(false);
                     if (installed.TryGetValue(id, out var installedGame))
                     {
+                        var game = installedGame.ToGame();
                         var installInfo = new GameInstallationData
                         {
-                            InstallDirectory = installedGame.InstallDirectory
+                            InstallDirectory = game.InstallDirectory
                         };
 
                         InvokeOnInstalled(new GameInstalledEventArgs(installInfo));
@@ -74,6 +80,21 @@ namespace SteamLibrary
                 }
             });
         }
+
+        private bool HandleVideos()
+        {
+            if (Game.Source.Name != SourceNames.Video)
+            {
+                return false;
+            }
+
+            var url = GetExtraUrl(Game.GameId);
+            ProcessStarter.StartUrl(url);
+            InvokeOnInstallationCancelled(new GameInstallationCancelledEventArgs());
+            return true;
+        }
+
+        private string GetExtraUrl(string steamId) => $"https://store.steampowered.com/video/watch/{steamId}";
     }
 
     public class SteamUninstallController : UninstallController
@@ -159,6 +180,7 @@ namespace SteamLibrary
 
         public override void Play(PlayActionArgs args)
         {
+
             Dispose();
 
             var steamExe = Steam.ClientExecPath;
@@ -171,9 +193,10 @@ namespace SteamLibrary
             if (gameId.IsMod)
             {
                 var allGames = SteamLocalService.GetInstalledGames(false);
-                if (allGames.TryGetValue(gameId.AppID.ToString(), out GameMetadata realGame))
+                if (allGames.TryGetValue(gameId.AppID.ToString(), out var realGame))
                 {
-                    installDirectory = realGame.InstallDirectory;
+                    var game = realGame.ToGame();
+                    installDirectory = game.InstallDirectory;
                 }
             }
 

--- a/source/Libraries/SteamLibrary/SteamLibrary.csproj
+++ b/source/Libraries/SteamLibrary/SteamLibrary.csproj
@@ -40,11 +40,8 @@
     <Reference Include="Microsoft.Xaml.Behaviors, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Xaml.Behaviors.Wpf.1.1.39\lib\net45\Microsoft.Xaml.Behaviors.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="Playnite.SDK">
-      <HintPath>..\..\packages\PlayniteSDK.6.4.0\lib\net462\Playnite.SDK.dll</HintPath>
+    <Reference Include="Playnite.SDK, Version=6.14.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\PlayniteSDK.6.14.0\lib\net462\Playnite.SDK.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
@@ -191,6 +188,7 @@
     <Compile Include="Environment.cs" />
     <Compile Include="GameExtension.cs" />
     <Compile Include="LocalizationKeys.cs" />
+    <Compile Include="Models\BackendModels.cs" />
     <Compile Include="Models\ApiResponseModels.cs" />
     <Compile Include="Models\SteamStoreModels.cs" />
     <Compile Include="Services\Base\SteamApiServiceBase.cs" />

--- a/source/Libraries/SteamLibrary/SteamLibrarySettingsView.xaml
+++ b/source/Libraries/SteamLibrary/SteamLibrarySettingsView.xaml
@@ -36,11 +36,18 @@
 
     <TabControl>
         <TabItem Header="{DynamicResource LOCGeneralLabel}">
+            <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
             <StackPanel Margin="20">
                 <CheckBox DockPanel.Dock="Top" Name="CheckSteamImportInstalled"
                           Margin="0,0,0,15"
-                          IsChecked="{Binding Settings.ImportInstalledGames}"
-                          Content="{DynamicResource LOCSteamSettingsImportInstalledLabel}"/>
+                          IsChecked="{Binding Settings.ImportInstalled}"
+                          Content="Import installed content"/><!--Content="{DynamicResource LOCSteamSettingsImportInstalledLabel}"-->
+
+                <CheckBox DockPanel.Dock="Top"
+                          Margin="10,0,0,15"
+                          IsChecked="{Binding Settings.ImportInstalledMods}"
+                          IsEnabled="{Binding IsChecked,ElementName=CheckSteamImportInstalled}"
+                          Content="Import installed GoldSrc/Source mods"/>
 
                 <StackPanel Orientation="Horizontal">
                     <CheckBox Name="CheckSteamConnectAccount" VerticalAlignment="Center"
@@ -74,14 +81,9 @@
                 </StackPanel>
 
                 <StackPanel Margin="40,5,5,0" IsEnabled="{Binding IsChecked, ElementName=CheckSteamConnectAccount}">
-                    <CheckBox Name="CheckSteamImportUninstalled"
-                              IsChecked="{Binding Settings.ImportUninstalledGames}"
+                    <CheckBox IsChecked="{Binding Settings.ImportInstalledIgnoreOthers}"
                               Margin="0,10,0,0"
-                              Content="{DynamicResource LOCSteamSettingsImportUninstalledLabel}"/>
-
-                    <CheckBox IsChecked="{Binding Settings.IgnoreOtherInstalled}"
-                              Margin="0,10,0,0"
-                              Content="{DynamicResource LOCSteamIgnoreOtherAccountGames}"/>
+                              Content="Ignore installed content from other accounts"/><!--Content="{DynamicResource LOCSteamIgnoreOtherAccountGames}"-->
 
                     <TextBlock VerticalAlignment="Center" Margin="0,15,0,0">
                         <Hyperlink NavigateUri="https://github.com/JosefNemec/PlayniteExtensions/wiki/Steam-troubleshooting#should-i-use-web-or-api-login"
@@ -91,23 +93,42 @@
                         </Hyperlink>
                     </TextBlock>
 
-                    <RadioButton Content="Web login" Margin="0,15,0,0"
-                                 IsChecked="{Binding Settings.IsPrivateAccount, Converter={StaticResource NegateConverter}}" />
 
-                    <Button Content="{DynamicResource LOCSteamAuthenticateLabel}"
-                            Command="{Binding LoginCommand}"
-                            IsEnabled="{Binding Settings.IsPrivateAccount, Converter={StaticResource NegateConverter}}"
-                            Margin="25,15,5,5" HorizontalAlignment="Left"/>
+                    <RadioButton Content="Web login" Margin="0,15" IsChecked="{Binding Settings.UseApiLogin, Converter={StaticResource NegateConverter}}" />
+                    <StackPanel Margin="10,0" IsEnabled="{Binding Settings.UseApiLogin,Converter={StaticResource NegateConverter}}">
+                        <Button Content="{DynamicResource LOCSteamAuthenticateLabel}"
+                                Command="{Binding LoginCommand}"
+                                Margin="0,5,5,5" HorizontalAlignment="Left"/>
+                        <TextBlock Text="Library import settings" Margin="0,15" VerticalAlignment="Center" MinWidth="150"/>
+                        <StackPanel Orientation="Horizontal" Margin="25,5">
+                            <TextBlock Text="Import Games" VerticalAlignment="Center" MinWidth="130"/>
+                            <CheckBox Margin="5,0" MinWidth="100" IsChecked="{Binding Settings.ImportGamesOwn}" Content="own"/>
+                            <CheckBox Margin="5,0" MinWidth="100" IsChecked="{Binding Settings.ImportGamesFamily}" Content="family"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Margin="25,5">
+                            <TextBlock Text="Import Apps" VerticalAlignment="Center" MinWidth="130"/>
+                            <CheckBox Margin="5,0" MinWidth="100" IsChecked="{Binding Settings.ImportAppsOwn}" Content="own" />
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Margin="25,5">
+                            <TextBlock Text="Import Media" VerticalAlignment="Center" MinWidth="130"/>
+                            <CheckBox Margin="5,0" MinWidth="100" IsChecked="{Binding Settings.ImportMediaOwn}" Content="own"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Margin="25,5">
+                            <TextBlock Text="Import Free Demos*" VerticalAlignment="Center" MinWidth="130"/>
+                            <CheckBox Margin="5,0" MinWidth="100" IsChecked="{Binding Settings.ImportFreeOwn}" Content="own"/>
+                            <CheckBox Margin="5,0" MinWidth="100" IsChecked="{Binding Settings.ImportFreeFamily}" Content="family"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Margin="25,5">
+                            <TextBlock Text="Import Tools*" VerticalAlignment="Center" MinWidth="130"/>
+                            <CheckBox Margin="5,0" MinWidth="100" IsChecked="{Binding Settings.ImportToolsOwn}" Content="own"/>
+                            <CheckBox Margin="5,0" MinWidth="100" IsChecked="{Binding Settings.ImportToolsFamily}" Content="family"/>
+                        </StackPanel>
+                        <TextBlock Text="*Demos and Tools require Steam client to be online during import" VerticalAlignment="Center" MinWidth="150" TextWrapping="Wrap" />
+                        <TextBlock Text="Tools import is not recommended. Steam itself shows a warning when you enable Tools in library. They are mostly servers, SDKs and other utilities. However, some games extras are listed as tools too. Also there are tools for games you don't own because that's how steam works." Visibility="{Binding Path=ToolsWarning,Converter={StaticResource BooleanToVisibilityConverter}}" VerticalAlignment="Center" MinWidth="150" Margin="0,10" TextWrapping="Wrap" />
+                    </StackPanel>
 
-                    <CheckBox IsChecked="{Binding Settings.ImportFamilySharedGames}" Margin="25,5,5,5"
-                              Content="{DynamicResource LOCSteamImportFamilyGames}"
-                              IsEnabled="{Binding Settings.IsPrivateAccount, Converter={StaticResource NegateConverter}}" />
-
-                    <RadioButton Content="API key login"  Margin="0,10,0,0"
-                                 IsChecked="{Binding Settings.IsPrivateAccount}" />
-
-                    <StackPanel IsEnabled="{Binding Settings.IsPrivateAccount}"
-                                Margin="25,0,0,0">
+                    <RadioButton Content="API key login" Margin="0,15" IsChecked="{Binding Settings.UseApiLogin}" />
+                    <StackPanel IsEnabled="{Binding Settings.UseApiLogin}" Margin="10,0">
                         <StackPanel DockPanel.Dock="Top" Margin="0,10,5,5" Orientation="Horizontal">
                             <TextBlock Text="{DynamicResource LOCSteamAccountID}"
                                        VerticalAlignment="Center" MinWidth="100"/>
@@ -137,10 +158,15 @@
                             </TextBlock>
                         </StackPanel>
 
-                        <CheckBox IsChecked="{Binding Settings.IncludeFreeSubGames}"
-                                  Margin="0,5,0,0"
-                                  Visibility="{Binding IsFirstRunUse, Converter={pcon:InvertedBooleanToVisibilityConverter}}"
-                                  Content="{DynamicResource LOCSteamImportFreeSubGames}"/>
+                        <TextBlock Text="Import by API is limited: games only, no family, missing free items" Margin="0,15" VerticalAlignment="Center" MinWidth="150"/>
+                        <StackPanel Orientation="Horizontal" Margin="25,5">
+                            <TextBlock Text="Import Games" VerticalAlignment="Center" MinWidth="130"/>
+                            <CheckBox Margin="5,0" MinWidth="100" IsChecked="{Binding Settings.ImportGamesOwn}" Content="own" />
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Margin="25,5">
+                            <TextBlock Text="Import Free Demos" VerticalAlignment="Center" MinWidth="130"/>
+                            <CheckBox Margin="5,0" MinWidth="100" IsChecked="{Binding Settings.ImportFreeOwn}" Content="own"/>
+                        </StackPanel>
                     </StackPanel>
                 </StackPanel>
                 <TextBlock VerticalAlignment="Center" Margin="0,15,0,0">
@@ -151,6 +177,7 @@
                     </Hyperlink>
                 </TextBlock>
             </StackPanel>
+            </ScrollViewer>
         </TabItem>
         <TabItem Header="{DynamicResource LOCSteamAdditionalAccounts}">
             <DockPanel Margin="10">

--- a/source/Libraries/SteamLibrary/SteamLibrarySettingsView.xaml.cs
+++ b/source/Libraries/SteamLibrary/SteamLibrarySettingsView.xaml.cs
@@ -1,17 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
+﻿using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 
 namespace SteamLibrary
 {

--- a/source/Libraries/SteamLibrary/SteamLibrarySettingsViewModel.cs
+++ b/source/Libraries/SteamLibrary/SteamLibrarySettingsViewModel.cs
@@ -1,17 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Playnite.Commands;
-using SteamLibrary.Models;
 using Playnite.SDK;
-using System.Windows.Media;
-using System.Diagnostics;
-using System.Text.RegularExpressions;
-using Steam;
 using System.Collections.ObjectModel;
 using SteamLibrary.SteamShared;
 using Playnite.SDK.Data;
@@ -32,31 +25,47 @@ namespace SteamLibrary
 
     public class SteamLibrarySettings : SharedSteamSettings
     {
-        private bool isPrivateAccount;
+        private bool useApiLogin;
+        private bool importGamesOwn = true;
+        private bool importFreeOwn = true;
+        private bool importToolsOwn;
+        private bool importToolsFamily;
         private string apiKey = string.Empty;
         private string userId = string.Empty;
 
         public int Version { get; set; }
-        public bool ImportInstalledGames { get; set; } = true;
-        public bool ImportFamilySharedGames { get; set; } = true;
+        [Obsolete]public bool ImportInstalledGames { get; set; } = true;
+        [Obsolete]public bool ImportFamilySharedGames { get; set; } = true;
         public bool ConnectAccount { get; set; } = false;
-        public bool ImportUninstalledGames { get; set; } = false;
+        [Obsolete]public bool ImportUninstalledGames { get; set; } = false;
         public string UserId { get => userId; set => SetValue(ref userId, value); }
-        public bool IncludeFreeSubGames { get; set; } = false;
+        [Obsolete]public bool IncludeFreeSubGames { get; set; } = false;
         public bool ShowFriendsButton { get; set; } = true;
-        public bool IgnoreOtherInstalled { get; set; }
+        [Obsolete]public bool IgnoreOtherInstalled { get; set; }
         public ObservableCollection<AdditionalSteamAccount> AdditionalAccounts { get; set; } = new ObservableCollection<AdditionalSteamAccount>();
         public bool ShowSteamLaunchMenuInDesktopMode { get; set; } = true;
         public bool ShowSteamLaunchMenuInFullscreenMode { get; set; } = false;
         public List<string> ExtraIDsToImport { get; set; }
         [Obsolete] public string ApiKey { get; set; }
-
         [DontSerialize] public string RuntimeApiKey { get => apiKey; set => SetValue(ref apiKey, value); }
+        [Obsolete] public bool IsPrivateAccount { get; set; }
 
-        public bool IsPrivateAccount
+        public bool ImportInstalled { get; set; } = true;
+        public bool ImportInstalledMods { get; set; } = true;
+        public bool ImportInstalledIgnoreOthers { get; set; }
+        public bool ImportGamesOwn { get => importGamesOwn; set => SetValue(ref importGamesOwn, value); }
+        public bool ImportGamesFamily { get; set; } = true;
+        public bool ImportAppsOwn { get; set; } = true;
+        public bool ImportMediaOwn { get; set; }
+        public bool ImportFreeOwn { get => importFreeOwn; set => SetValue(ref importFreeOwn, value); }
+        public bool ImportFreeFamily { get; set; }
+        public bool ImportToolsOwn { get => importToolsOwn; set => SetValue(ref importToolsOwn, value); }
+        public bool ImportToolsFamily { get => importToolsFamily; set => SetValue(ref importToolsFamily, value); }
+
+        public bool UseApiLogin
         {
-            get => isPrivateAccount;
-            set => SetValue(ref isPrivateAccount, value);
+            get => useApiLogin;
+            set => SetValue(ref useApiLogin, value);
         }
     }
 
@@ -74,9 +83,9 @@ namespace SteamLibrary
             {
                 try
                 {
-                    if (Settings.IsPrivateAccount)
+                    if (Settings.UseApiLogin)
                     {
-                        var res = new PlayerService().GetOwnedGamesApiKey(Settings, ulong.Parse(Settings.UserId), Settings.RuntimeApiKey, true);
+                        var res = new PlayerService().GetOwnedGamesApiKey(Settings, ulong.Parse(Settings.UserId), Settings.RuntimeApiKey);
                         return res?.Any() == true;
                     }
                     else
@@ -92,6 +101,8 @@ namespace SteamLibrary
                 }
             }
         }
+
+        public bool ToolsWarning => Settings.ImportToolsOwn || Settings.ImportToolsFamily;
 
         public RelayCommand<object> LoginCommand => new RelayCommand<object>(_ =>
         {
@@ -131,6 +142,7 @@ namespace SteamLibrary
 
         protected override void OnLoadSettings()
         {
+#pragma warning disable CS0612 // Type or member is obsolete
             if (Settings.Version == 0)
             {
                 Logger.Debug("Updating Steam settings from version 0.");
@@ -141,19 +153,30 @@ namespace SteamLibrary
             }
             else if (Settings.Version == 1)
             {
-#pragma warning disable CS0612 // Type or member is obsolete
+                Logger.Debug("Updating Steam settings from version 1.");
                 Settings.RuntimeApiKey = Settings.ApiKey;
                 Settings.AdditionalAccounts.ForEach(a => a.RuntimeApiKey = a.ApiKey);
                 Settings.ApiKey = null;
                 Settings.AdditionalAccounts.ForEach(a => a.ApiKey = null);
-#pragma warning restore CS0612 // Type or member is obsolete
 
                 SaveKeys();
                 Settings.Version = 2;
                 Plugin.SavePluginSettings(Settings);
             }
+            else if (Settings.Version == 2)
+            {
+                Logger.Debug("Updating Steam settings from version 2.");
+                Settings.ImportInstalled = Settings.ImportInstalledGames;
+                Settings.ImportInstalledMods = Settings.ImportInstalledGames;
+                Settings.ImportInstalledIgnoreOthers = Settings.IgnoreOtherInstalled;
+                Settings.ImportGamesOwn = Settings.ImportUninstalledGames;
+                Settings.ImportGamesFamily = Settings.ImportFamilySharedGames;
+                Settings.ImportFreeOwn = Settings.IncludeFreeSubGames;
+                Settings.UseApiLogin = Settings.IsPrivateAccount;
+            }
+#pragma warning restore CS0612 // Type or member is obsolete
 
-            Settings.Version = 2;
+            Settings.Version = 3;
             LoadKeys();
         }
 
@@ -219,17 +242,23 @@ namespace SteamLibrary
 
         private void Settings_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            if (e.PropertyName == nameof(SteamLibrarySettings.IsPrivateAccount) ||
+            if (e.PropertyName == nameof(SteamLibrarySettings.UseApiLogin) ||
                 e.PropertyName == nameof(SteamLibrarySettings.RuntimeApiKey) ||
                 e.PropertyName == nameof(SteamLibrarySettings.UserId))
             {
                 OnPropertyChanged(nameof(IsUserLoggedIn));
             }
+            else if(e.PropertyName == nameof(SteamLibrarySettings.ImportToolsOwn) ||
+                    e.PropertyName == nameof(SteamLibrarySettings.ImportToolsFamily)
+                    )
+            {
+                OnPropertyChanged(nameof(ToolsWarning));
+            }
         }
 
         public override bool VerifySettings(out List<string> errors)
         {
-            if (Settings.IsPrivateAccount && Settings.RuntimeApiKey.IsNullOrEmpty())
+            if (Settings.UseApiLogin && Settings.RuntimeApiKey.IsNullOrEmpty())
             {
                 errors = new List<string> { "Steam API key must be specified when using private accounts!" };
                 return false;

--- a/source/Libraries/SteamLibrary/SteamMetadataProvider.cs
+++ b/source/Libraries/SteamLibrary/SteamMetadataProvider.cs
@@ -1,16 +1,6 @@
 ﻿using Playnite.SDK;
 using Playnite.SDK.Models;
 using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Net;
-using System.Text;
-using System.Text.RegularExpressions;
-using System.Threading;
-using System.Threading.Tasks;
 using Steam;
 using Playnite.Common.Web;
 using SteamLibrary.Services;
@@ -51,7 +41,7 @@ namespace SteamLibrary
             var gameId = game.ToSteamGameID();
             if (gameId.IsMod)
             {
-                return SteamLocalService.GetInstalledModFromFolder(game.InstallDirectory, ModInfo.GetModTypeOfGameID(gameId));
+                return SteamLocalService.GetInstalledModFromFolder(game.InstallDirectory, ModInfo.GetModTypeOfGameID(gameId)).ToGame();
             }
             else
             {

--- a/source/Libraries/SteamLibrary/packages.config
+++ b/source/Libraries/SteamLibrary/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="AngleSharp" version="0.9.9" targetFramework="net462" />
   <package id="Microsoft.Xaml.Behaviors.Wpf" version="1.1.39" targetFramework="net462" />
-  <package id="PlayniteSDK" version="6.0.0" targetFramework="net462" />
+  <package id="PlayniteSDK" version="6.14.0" targetFramework="net462" />
   <package id="protobuf-net" version="2.0.0.668" targetFramework="net462" />
   <package id="SteamKit2" version="1.8.3" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
This started as an attempt to allow importing non-game extras like i did with GOG and Humble. Head-on approach failed, because steam import uses different places (installed files, multiple endpoints), there are a lot of content types that are hard to reason about, and also family sharing. So i decided to take a closer look on actual data from different places and figure out how to cook it all together. End result is rework of UI, settings, types, what APIs are used. Hope it helps keeping steam import sane for any future changes.

Main ideas: call only endpoints that return most info, have types with actual data until final import step, filter them all in one place, enrich all entries with details from playnite backend, provide settings that are close as possible to steam, avoid mixing up some things as steam does.

Steam data from different APIs is inconsistent, i spent a lot of time making it make sense in code. If it's not clear why something is the way it is, ask me. There are some comments and TODOs in the code where things are really not obvious or where discussion is needed. Localization strings are TODO after everything else is figured out.

Start with `SteamLibrarySettingsView.xaml`, i guess. Most important code is in `SteamServiceAggregator`. Then check out API clients and models.

Oh and code from master didn't compile for me after clean checkout, i had to fix some dll references. Did not include these changes here.