### PR TITLE
Steam: update playtimes for games that aren't in the import but are in the library already

### DIFF
--- a/source/Libraries/SteamLibrary/Services/Base/SteamApiServiceBase.cs
+++ b/source/Libraries/SteamLibrary/Services/Base/SteamApiServiceBase.cs
@@ -62,7 +62,10 @@ namespace SteamLibrary.Services.Base
             if (unixEpochSeconds == 0)
                 return null;
 
-            return DateTimeOffset.FromUnixTimeSeconds(unixEpochSeconds).LocalDateTime;
+            var lastPlayed = DateTimeOffset.FromUnixTimeSeconds(unixEpochSeconds).LocalDateTime;
+
+            // Some games last played before Steam started storing last played times (about 2008?) report as last played 1970-01-02 00:00:00 UTC
+            return lastPlayed.Year < 2004 ? null : lastPlayed;
         }
     }
 

--- a/source/Libraries/SteamLibrary/Services/SourceNames.cs
+++ b/source/Libraries/SteamLibrary/Services/SourceNames.cs
@@ -1,9 +1,24 @@
+using System;
+using System.Linq;
+
 namespace SteamLibrary.Services
 {
     public static class SourceNames
     {
         public const string Steam = "Steam";
         public const string FamilySharing = "Steam Family Sharing";
-        public static readonly string[] AllKnown = { Steam, FamilySharing };
+        private static readonly string[] updatableSources = [Steam, FamilySharing];
+
+        /// <summary>
+        /// This source is only assigned to games already in the Playnite library.
+        /// By not being in UpdatableSources, games that we don't actually know the original source of won't get their source overridden.
+        /// Since this source isn't assigned to new games, it won't normally be seen by users.
+        /// </summary>
+        public const string PlaytimeOnly = "Steam playtime only (missing from normal import)";
+
+        public static bool IsUpdatableSource(string source)
+        {
+            return updatableSources.Contains(source, StringComparer.InvariantCultureIgnoreCase);
+        }
     }
 }

--- a/source/Libraries/SteamLibrary/Services/SteamServiceAggregator.cs
+++ b/source/Libraries/SteamLibrary/Services/SteamServiceAggregator.cs
@@ -157,10 +157,7 @@ namespace SteamLibrary.Services
 
                     TryAddGames(() => playerService.GetOwnedGamesApiKey(settings, ulong.Parse(settings.UserId), settings.RuntimeApiKey, settings.IncludeFreeSubGames), "PlayerService (API key)", onlineLibraryGameIds, true);
 
-                    TryAddPlayTimes(() => playerService.GetClientLastPlayedTimesApiKey(settings.RuntimeApiKey, settings.LastPlayTimeSync), "API key");
-
-                    settings.LastPlayTimeSync = DateTimeOffset.Now;
-                    plugin.SavePluginSettings(settings);
+                    TryAddPlayTimes(() => playerService.GetClientLastPlayedTimesApiKey(settings.RuntimeApiKey), "API key");
                 }
                 else
                 {
@@ -176,7 +173,7 @@ namespace SteamLibrary.Services
                         if (settings.ImportFamilySharedGames || settings.ImportInstalledGames)
                             TryAddGames(() => familyGroupsService.GetSharedGames(settings, userToken, out familySharingUserIds), "Family Sharing", onlineLibraryGameIds, overwriteName: true, familySharingGames: true);
 
-                        TryAddPlayTimes(() => playerService.GetClientLastPlayedTimesWeb(userToken, settings.LastPlayTimeSync), "Web");
+                        TryAddPlayTimes(() => playerService.GetClientLastPlayedTimesWeb(userToken), "Web");
 
                         var allower = parentalService.GetParentalAppAllower(userToken);
                         foreach (var game in new List<GameMetadata>(allGames.Values))
@@ -187,9 +184,6 @@ namespace SteamLibrary.Services
                             logger.Info($"Parental restriction: removing {game.Name} ({game.GameId}) from import");
                             allGames.Remove(game.GameId);
                         }
-
-                        settings.LastPlayTimeSync = DateTimeOffset.Now;
-                        plugin.SavePluginSettings(settings);
                     }
                     catch (Exception e)
                     {

--- a/source/Libraries/SteamLibrary/Services/SteamServiceAggregator.cs
+++ b/source/Libraries/SteamLibrary/Services/SteamServiceAggregator.cs
@@ -129,6 +129,7 @@ namespace SteamLibrary.Services
                                 Name = libraryGamesWithThisId.FirstOrDefault()?.Name,
                                 Playtime = playtimeSeconds,
                                 LastActivity = lastPlayed,
+                                Source = new MetadataNameProperty(SourceNames.PlaytimeOnly),
                             };
                             AddGame(playtimeGame);
                         }
@@ -318,9 +319,10 @@ namespace SteamLibrary.Services
                     bool update = false;
 
                     var oldSource = existingGame.Source;
-                    if (SourceNames.AllKnown.Contains(oldSource?.Name, StringComparer.InvariantCultureIgnoreCase))
+                    var newSourceName = ((MetadataNameProperty)newGame.Source).Name;
+                    if (SourceNames.IsUpdatableSource(oldSource?.Name) && SourceNames.IsUpdatableSource(newSourceName))
                     {
-                        var newSource = GetOrCreateSource(((MetadataNameProperty)newGame.Source).Name);
+                        var newSource = GetOrCreateSource(newSourceName);
 
                         if (oldSource?.Id != newSource.Id)
                         {

--- a/source/Libraries/SteamLibrary/Services/SteamServiceAggregator.cs
+++ b/source/Libraries/SteamLibrary/Services/SteamServiceAggregator.cs
@@ -55,15 +55,15 @@ namespace SteamLibrary.Services
 
                 if (gameAlreadyInImport)
                 {
-                if (overwriteName)
-                    existingGame.Name = game.Name;
+                    if (overwriteName)
+                        existingGame.Name = game.Name;
 
-                if (existingGame.Playtime == 0)
-                    existingGame.Playtime = game.Playtime;
+                    if (existingGame.Playtime == 0)
+                        existingGame.Playtime = game.Playtime;
 
-                existingGame.InstallSize ??= game.InstallSize;
-                existingGame.LastActivity ??= game.LastActivity;
-                existingGame.Source ??= game.Source;
+                    existingGame.InstallSize ??= game.InstallSize;
+                    existingGame.LastActivity ??= game.LastActivity;
+                    existingGame.Source ??= game.Source;
                 }
                 else
                 {
@@ -105,7 +105,6 @@ namespace SteamLibrary.Services
                                                                              .GroupBy(g => g.GameId)
                                                                              .ToDictionary(gr => gr.Key, gr => gr.ToList());
 
-                    using var bufferedUpdate = playniteApi.Database.BufferedUpdate();
                     foreach (var playtime in playTimes)
                     {
                         string idStr = playtime.appid.ToString();
@@ -119,29 +118,19 @@ namespace SteamLibrary.Services
 
                             if (game.LastActivity == null || game.LastActivity < lastPlayed)
                                 game.LastActivity = lastPlayed;
-
-                            continue;
                         }
-
-                        if (playniteApi.ApplicationSettings.PlaytimeImportMode == PlaytimeImportMode.Always && libraryGames.TryGetValue(idStr, out var libraryGamesWithThisId))
+                        else  if (libraryGames.TryGetValue(idStr, out var libraryGamesWithThisId))
                         {
-                            foreach (var libGame in libraryGamesWithThisId)
+                            // Add games to import result as a way to potentially update their playtimes
+                            // We don't add these for games that aren't already in the Playnite library because that would include demos and refunded games
+                            var playtimeGame = new GameMetadata
                             {
-                                bool setPlaytime = libGame.Playtime < playtimeSeconds;
-                                bool setLastPlayed = libGame.LastActivity == null || libGame.LastActivity < lastPlayed;
-
-                                if (setPlaytime)
-                                    libGame.Playtime = playtimeSeconds;
-
-                                if (setLastPlayed)
-                                    libGame.LastActivity = lastPlayed;
-
-                                if (setPlaytime || setLastPlayed)
-                                {
-                                    libGame.Modified = DateTime.Now;
-                                    playniteApi.Database.Games.Update(libGame);
-                                }
-                            }
+                                GameId = idStr,
+                                Name = libraryGamesWithThisId.FirstOrDefault()?.Name,
+                                Playtime = playtimeSeconds,
+                                LastActivity = lastPlayed,
+                            };
+                            AddGame(playtimeGame);
                         }
                     }
                 }

--- a/source/Libraries/SteamLibrary/Services/SteamServiceAggregator.cs
+++ b/source/Libraries/SteamLibrary/Services/SteamServiceAggregator.cs
@@ -101,19 +101,48 @@ namespace SteamLibrary.Services
                     var playTimes = getPlayTimesFunc().ToList();
                     logger.Info($"Found {playTimes.Count} {importSource} Steam play times.");
 
+                    Dictionary<string, List<Game>> libraryGames = playniteApi.Database.Games.Where(g => g.PluginId == plugin.Id)
+                                                                             .GroupBy(g => g.GameId)
+                                                                             .ToDictionary(gr => gr.Key, gr => gr.ToList());
+
+                    using var bufferedUpdate = playniteApi.Database.BufferedUpdate();
                     foreach (var playtime in playTimes)
                     {
-                        if (!allGames.TryGetValue(playtime.appid.ToString(), out var game))
-                            continue;
-
+                        string idStr = playtime.appid.ToString();
                         ulong playtimeSeconds = (playtime.playtime_forever + playtime.playtime_disconnected) * 60;
                         var lastPlayed = SteamApiServiceBase.GetLastPlayedDateTime(playtime.last_playtime);
 
-                        if (game.Playtime < playtimeSeconds)
-                            game.Playtime = playtimeSeconds;
+                        if (allGames.TryGetValue(idStr, out var game))
+                        {
+                            if (game.Playtime < playtimeSeconds)
+                                game.Playtime = playtimeSeconds;
 
-                        if (game.LastActivity == null || game.LastActivity < lastPlayed)
-                            game.LastActivity = lastPlayed;
+                            if (game.LastActivity == null || game.LastActivity < lastPlayed)
+                                game.LastActivity = lastPlayed;
+
+                            continue;
+                        }
+
+                        if (playniteApi.ApplicationSettings.PlaytimeImportMode == PlaytimeImportMode.Always && libraryGames.TryGetValue(idStr, out var libraryGamesWithThisId))
+                        {
+                            foreach (var libGame in libraryGamesWithThisId)
+                            {
+                                bool setPlaytime = libGame.Playtime < playtimeSeconds;
+                                bool setLastPlayed = libGame.LastActivity == null || libGame.LastActivity < lastPlayed;
+
+                                if (setPlaytime)
+                                    libGame.Playtime = playtimeSeconds;
+
+                                if (setLastPlayed)
+                                    libGame.LastActivity = lastPlayed;
+
+                                if (setPlaytime || setLastPlayed)
+                                {
+                                    libGame.Modified = DateTime.Now;
+                                    playniteApi.Database.Games.Update(libGame);
+                                }
+                            }
+                        }
                     }
                 }
                 catch (Exception e)

--- a/source/Libraries/SteamLibrary/SteamLibrarySettingsViewModel.cs
+++ b/source/Libraries/SteamLibrary/SteamLibrarySettingsViewModel.cs
@@ -49,7 +49,6 @@ namespace SteamLibrary
         public bool ShowSteamLaunchMenuInDesktopMode { get; set; } = true;
         public bool ShowSteamLaunchMenuInFullscreenMode { get; set; } = false;
         public List<string> ExtraIDsToImport { get; set; }
-        public DateTimeOffset? LastPlayTimeSync { get; set; } = null;
         [Obsolete] public string ApiKey { get; set; }
 
         [DontSerialize] public string RuntimeApiKey { get => apiKey; set => SetValue(ref apiKey, value); }


### PR DESCRIPTION
I'm not entirely happy with this one, feel free to shoot it down.

This is a workaround for a user who consistently gets an empty response from https://steamapi.xpaw.me/IClientCommService#GetClientAppList
Long reddit thread for context here: https://www.reddit.com/r/playnite/comments/1v19b5v/ive_figured_whats_causing_the_steam_nontracking/

The fact that that API fails to return any games is a huge issue imo, and I don't know if we have alternatives to it. It not working means that any profile-features-limited games will not import unless installed, which sucks.

So this workaround, instead of fixing the issue, assigns playtimes to games that have been imported before but aren't part of the current import. As a plus, that also includes stuff like demos that have been uninstalled (which removes them from GetClientAppList too).