### PR TITLE
Add option to skip cover/background/icon image downloads in IGDB metadata

### DIFF
--- a/source/Metadata/IGDBMetadata/IgdbLazyMetadataProvider.cs
+++ b/source/Metadata/IGDBMetadata/IgdbLazyMetadataProvider.cs
@@ -74,7 +74,8 @@ namespace IGDBMetadata
 
         public override MetadataFile GetBackgroundImage(GetMetadataFieldArgs args)
         {
-            if (!AvailableFields.Contains(MetadataField.BackgroundImage))
+            if (!AvailableFields.Contains(MetadataField.BackgroundImage) ||
+                plugin.SettingsViewModel.Settings.SkipBackgroundImage)
             {
                 return base.GetBackgroundImage(args);
             }
@@ -152,7 +153,8 @@ namespace IGDBMetadata
 
         public override MetadataFile GetCoverImage(GetMetadataFieldArgs args)
         {
-            if (!AvailableFields.Contains(MetadataField.CoverImage))
+            if (!AvailableFields.Contains(MetadataField.CoverImage) ||
+                plugin.SettingsViewModel.Settings.SkipCoverImage)
             {
                 return base.GetCoverImage(args);
             }
@@ -162,7 +164,8 @@ namespace IGDBMetadata
 
         public override MetadataFile GetIcon(GetMetadataFieldArgs args)
         {
-            if (!AvailableFields.Contains(MetadataField.Icon))
+            if (!AvailableFields.Contains(MetadataField.Icon) ||
+                plugin.SettingsViewModel.Settings.SkipIcon)
             {
                 return base.GetCoverImage(args);
             }
@@ -332,20 +335,28 @@ namespace IGDBMetadata
 
                 if (GameData.cover_expanded != null && !GameData.cover_expanded.url.IsNullOrEmpty())
                 {
-                    fields.Add(MetadataField.CoverImage);
-                    if (plugin.SettingsViewModel.Settings.UseCoverAsIcon)
+                    if (!plugin.SettingsViewModel.Settings.SkipCoverImage)
+                    {
+                        fields.Add(MetadataField.CoverImage);
+                    }
+
+                    if (plugin.SettingsViewModel.Settings.UseCoverAsIcon &&
+                        !plugin.SettingsViewModel.Settings.SkipIcon)
                     {
                         fields.Add(MetadataField.Icon);
                     }
                 }
 
-                if (GameData.artworks_expanded.HasItems())
+                if (!plugin.SettingsViewModel.Settings.SkipBackgroundImage)
                 {
-                    fields.Add(MetadataField.BackgroundImage);
-                }
-                else if (GameData.screenshots_expanded.HasItems() && plugin.SettingsViewModel.Settings.UseScreenshotsIfNecessary)
-                {
-                    fields.Add(MetadataField.BackgroundImage);
+                    if (GameData.artworks_expanded.HasItems())
+                    {
+                        fields.Add(MetadataField.BackgroundImage);
+                    }
+                    else if (GameData.screenshots_expanded.HasItems() && plugin.SettingsViewModel.Settings.UseScreenshotsIfNecessary)
+                    {
+                        fields.Add(MetadataField.BackgroundImage);
+                    }
                 }
 
                 if (GameData.first_release_date != 0)

--- a/source/Metadata/IGDBMetadata/IgdbMetadataSettingsView.xaml
+++ b/source/Metadata/IGDBMetadata/IgdbMetadataSettingsView.xaml
@@ -38,5 +38,15 @@
                 </ComboBox.ItemTemplate>
             </ComboBox>
         </StackPanel>
+
+        <Separator Margin="0,20,0,10"/>
+        <TextBlock Text="{DynamicResource LOCIgdbSkipImagesHeader}" FontWeight="Bold" Margin="0,0,0,5"/>
+
+        <CheckBox Content="{DynamicResource LOCIgdbSkipCoverImage}" Margin="0,5,0,0"
+                  IsChecked="{Binding Settings.SkipCoverImage}"/>
+        <CheckBox Content="{DynamicResource LOCIgdbSkipBackgroundImage}" Margin="0,5,0,0"
+                  IsChecked="{Binding Settings.SkipBackgroundImage}"/>
+        <CheckBox Content="{DynamicResource LOCIgdbSkipIcon}" Margin="0,5,0,0"
+                  IsChecked="{Binding Settings.SkipIcon}"/>
     </StackPanel>
 </UserControl>

--- a/source/Metadata/IGDBMetadata/IgdbMetadataSettingsViewModel.cs
+++ b/source/Metadata/IGDBMetadata/IgdbMetadataSettingsViewModel.cs
@@ -23,6 +23,9 @@ namespace IGDBMetadata
         public bool UseScreenshotsIfNecessary { get; set; } = false;
         public MultiImagePriority ImageSelectionPriority { get; set; } = MultiImagePriority.First;
         public bool UseCoverAsIcon { get; set; } = false;
+        public bool SkipCoverImage { get; set; } = false;
+        public bool SkipBackgroundImage { get; set; } = false;
+        public bool SkipIcon { get; set; } = false;
     }
 
     public class IgdbMetadataSettingsViewModel : PluginSettingsViewModel<IgdbMetadataSettings, IgdbMetadataPlugin>

--- a/source/Metadata/IGDBMetadata/Localization/en_US.xaml
+++ b/source/Metadata/IGDBMetadata/Localization/en_US.xaml
@@ -27,4 +27,8 @@
   <sys:String x:Key="LOCIgdbMultipleArtworkOptionsTitle">If multiple images are available then use:</sys:String>
   <sys:String x:Key="LOCIgdbSelectBackgroundTitle">Select background image for {0}</sys:String>
   <sys:String x:Key="LOCIgdbCoverAsIcon">Substitute cropped cover image for icon</sys:String>
+  <sys:String x:Key="LOCIgdbSkipImagesHeader">Skip image downloads</sys:String>
+  <sys:String x:Key="LOCIgdbSkipCoverImage">Do not download cover image</sys:String>
+  <sys:String x:Key="LOCIgdbSkipBackgroundImage">Do not download background image</sys:String>
+  <sys:String x:Key="LOCIgdbSkipIcon">Do not download icon</sys:String>
 </ResourceDictionary>

--- a/source/Metadata/IGDBMetadata/Localization/pt_BR.xaml
+++ b/source/Metadata/IGDBMetadata/Localization/pt_BR.xaml
@@ -26,4 +26,8 @@
   <sys:String x:Key="LOCIgdbMultipleArtworkOptionsTitle">Se houverem várias imagens disponíveis, usar:</sys:String>
   <sys:String x:Key="LOCIgdbSelectBackgroundTitle">Selecionar imagem de fundo para {0}</sys:String>
   <sys:String x:Key="LOCIgdbCoverAsIcon">Usar imagem de capa cortada como ícone</sys:String>
+  <sys:String x:Key="LOCIgdbSkipImagesHeader">Ignorar download de imagens</sys:String>
+  <sys:String x:Key="LOCIgdbSkipCoverImage">Não baixar imagem de capa</sys:String>
+  <sys:String x:Key="LOCIgdbSkipBackgroundImage">Não baixar imagem de fundo</sys:String>
+  <sys:String x:Key="LOCIgdbSkipIcon">Não baixar ícone</sys:String>
 </ResourceDictionary>

--- a/source/Metadata/IGDBMetadata/LocalizationKeys.cs
+++ b/source/Metadata/IGDBMetadata/LocalizationKeys.cs
@@ -113,5 +113,21 @@ namespace System
         /// Substitute cropped cover image for icon
         /// </summary>
         public const string IgdbCoverAsIcon = "LOCIgdbCoverAsIcon";
+        /// <summary>
+        /// Skip image downloads
+        /// </summary>
+        public const string IgdbSkipImagesHeader = "LOCIgdbSkipImagesHeader";
+        /// <summary>
+        /// Do not download cover image
+        /// </summary>
+        public const string IgdbSkipCoverImage = "LOCIgdbSkipCoverImage";
+        /// <summary>
+        /// Do not download background image
+        /// </summary>
+        public const string IgdbSkipBackgroundImage = "LOCIgdbSkipBackgroundImage";
+        /// <summary>
+        /// Do not download icon
+        /// </summary>
+        public const string IgdbSkipIcon = "LOCIgdbSkipIcon";
     }
 }


### PR DESCRIPTION
## Summary
Adds an option to skip downloading cover, background, and icon images in the IGDB metadata plugin. Useful for users with large libraries who want the rest of the metadata (name, description, release date, etc.) without spending time/bandwidth/storage on images.

## Changes
- Added `SkipCoverImage`, `SkipBackgroundImage`, and `SkipIcon` settings
- Added matching checkboxes to the plugin settings UI
- Updated `GetAvailableFields()` and the per-field getters to respect the new settings
- Added English and Portuguese (Brazil) localization strings

## Note
**This change was implemented with AI assistance (Claude).**

<img width="502" height="266" alt="image" src="https://github.com/user-attachments/assets/cfb66d58-a2bd-4be9-b318-4fd735694c03" />
